### PR TITLE
Kingdom Funding gateway via NMI (replaces Accept Blue)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ dist/
 .tsbuildinfo
 
 # Environment files
+.env
+.env.*
 !.env.sample
 
 # IDE files

--- a/NMI_MIGRATION_HANDOFF.md
+++ b/NMI_MIGRATION_HANDOFF.md
@@ -1,0 +1,98 @@
+# Kingdom Funding Gateway — Accept Blue → NMI Migration (Handoff)
+
+**Prepared by RevitPay for the B1 Church App dev team.**
+
+## 1. What this is
+
+The Kingdom Funding payment gateway has been migrated from **Accept Blue** to **NMI** (Network Merchants Inc.).
+
+**Why:** Accept Blue cannot tokenize ACH/eCheck. NMI's **Collect.js** tokenizes *both* cards and ACH into a single-use `payment_token`, so donors can now give by bank account as well as card.
+
+**Scope is intentionally narrow:** the "Kingdom Funding" name, branding, signup flow, locale strings, dropdown labels, and the admin gateway-settings page are **unchanged**. Only the gateway's internal calls changed.
+
+## 2. Where the code is
+
+Work was done in private mirrors under the **RevitPay** GitHub org, on branch **`nmi-gateway`** (base `main`). Open PRs to review and merge:
+
+| Repo | PR | Notes |
+|------|----|-------|
+| RevitPay/B1Api | https://github.com/RevitPay/B1Api/pull/1 | Backend gateway provider + controllers |
+| RevitPay/Packages | https://github.com/RevitPay/Packages/pull/1 | apphelper donation components (Collect.js) |
+| RevitPay/B1Admin | https://github.com/RevitPay/B1Admin/pull/1 | One comment fix (gateway settings) |
+| B1App | — | No changes (consumes apphelper) |
+
+> To review/merge, your team needs collaborator access to these RevitPay repos (or we can transfer them / re-target the PRs to a repo you own — your call). RevitPay does **not** merge these; your team does.
+
+## 3. What changed
+
+### Backend — `B1Api`
+- **`src/shared/helpers/gateways/KingdomFundingGatewayProvider.ts`** — fully reimplemented against the **NMI Payment API** (`POST https://secure.nmi.com/api/transact.php`, form-urlencoded, url-encoded responses, `response=1` = approved):
+  - One-time **card + ACH** charge via Collect.js `payment_token` (raw routing/account ACH path also supported).
+  - **Customer Vault** (`add_customer`/`add_billing`/`delete_*`) for saved payment methods (`customer_vault_id`).
+  - **Recurring** via `add_subscription` / `update_subscription` / `delete_subscription` (vault the method, charge-today-if-applicable, then schedule).
+  - **Refund/void** (`type=refund` / `type=void`).
+  - **Webhook** verification: `Webhook-Signature: t=<nonce>,s=<hmac>`, HMAC-SHA256 over `<nonce>.<rawBody>`, timing-safe compare.
+- **`DonateController.ts`** — updated the KF charge + webhook glue that still assumed Accept Blue conventions (removed `nonce-`/`pm-` token prefixes; recognize NMI vault UUIDs; NMI webhook event names `transaction.sale.success` / `check.*`; label ACH donations as method "ACH").
+- **`CustomerController.ts` / `PaymentMethodController.ts`** — recurring-schedule normalization and payment-method delete updated to NMI's shape (status string vs `active` flag, vault UUIDs, `customer_vault_id`).
+- **Tests:** `src/shared/helpers/gateways/__tests__/KingdomFundingGatewayProvider.test.ts` covers webhook signature verification (string + raw-buffer body, tamper/missing-key rejection).
+- **`tools/seed-nmi-gateway.ts`** — local-dev helper that adds a Kingdom Funding/NMI gateway row to a church (see §5).
+
+### Frontend — `Packages/apphelper`
+- **`KingdomFundingTokenForm.tsx`** — replaced the Accept Blue hosted iframe with **NMI Collect.js**; supports `paymentMethod` `"card"` or `"ach"`; returns the NMI `payment_token` (result is backward-compatible with existing card callers).
+- **`MultiGatewayDonationForm.tsx`, `KingdomFundingNonAuthDonationInner.tsx`, `PaymentMethods.tsx`** — added a Card / Bank (ACH) toggle and route `type:"bank"` with the token; removed the old un-tokenized routing/account inputs and the `KF_ACH_ENABLED=false` gates.
+- Locale strings `payWithCard` / `payWithBank` added.
+
+## 4. Configuration (per church)
+
+Credentials live in the existing `gateways` table (encrypted at rest) and are entered on the B1Admin gateway-settings page — **column meaning is unchanged**, only the values are NMI's:
+
+| Column | Value |
+|--------|-------|
+| `publicKey` | NMI **Collect.js tokenization key** (public; used in the browser) |
+| `privateKey` | NMI **Security Key** (server-side secret) |
+| `webhookKey` | NMI **webhook signing key** |
+| `provider` | `kingdomfunding` |
+
+### Webhook
+- **NMI does not generate a signing key for you** — you create your own secret, enter it on the NMI webhook endpoint, and store the same value as `webhookKey`.
+- Endpoint URL to register in NMI (Settings → Webhooks):
+  `https://<api-host>/giving/donate/webhook/kingdomfunding?churchId=<CHURCH_ID>`
+- Subscribe to: `transaction.sale.success`, `transaction.auth.success`, refund events, and the ACH **check status** events.
+
+## 5. How to run/test locally
+
+Requires Node + MySQL 8 (Docker is easiest).
+
+```bash
+# 1. MySQL
+docker run -d --name b1-mysql -e MYSQL_ROOT_PASSWORD=b1local -p 3306:3306 mysql:8
+docker exec b1-mysql mysql -uroot -pb1local -e \
+  "CREATE DATABASE membership; CREATE DATABASE attendance; CREATE DATABASE content; \
+   CREATE DATABASE giving; CREATE DATABASE messaging; CREATE DATABASE doing; CREATE DATABASE reporting;"
+
+# 2. B1Api/.env (gitignored) — set connection strings + secrets, e.g.
+#   ENVIRONMENT=dev  SERVER_PORT=8084
+#   ENCRYPTION_KEY=<32 chars>  JWT_SECRET=<any>
+#   <MODULE>_CONNECTION_STRING=mysql://root:b1local@localhost:3306/<module>   (per module)
+#   NMI_SECURITY_KEY=...  NMI_TOKENIZATION_KEY=...  NMI_WEBHOOK_KEY=...  NMI_API_URL=https://secure.nmi.com/api/transact.php
+
+cd B1Api
+npm install
+npm run migrate:up        # schema for all modules
+npm run populateDemo      # seeds Grace Community Church (CHU00000001)
+npx tsx tools/seed-nmi-gateway.ts   # adds a kingdomfunding gateway to Grace with the .env NMI keys
+npm run dev               # http://localhost:8084
+```
+
+Then drive a donation through Collect.js (card or ACH); the charge flows to the NMI sandbox and a donation row is written to `giving.donations`. NMI sandbox test card: `4111111111111111`, any future expiry, CVV `999`. ACH test: routing `123123123`, account `123456789`.
+
+## 6. Verification already done
+
+- `tsc` clean on B1Api and apphelper; 17/17 gateway unit tests pass.
+- Live NMI sandbox: card, debit, ACH, Customer Vault, recurring, void, refund all approved.
+- Full end-to-end in a real browser (Collect.js → B1Api → NMI sandbox → donation + fund allocation logged) for **card and ACH**.
+
+## 7. Recommended before go-live
+
+1. **Live webhook delivery test** — point an NMI webhook at a publicly reachable instance (or a tunnel) and confirm ACH settlement/return events post donations. The signature verification is unit-tested; only the live round-trip remains.
+2. **Confirm NMI Query API field names** — the "view recurring donations" and "saved payment methods" screens read NMI `query.php` (XML). The field mapping is best-effort and marked in code; verify against a live subscription/vault list once there's recurring data in your NMI account.

--- a/src/modules/giving/controllers/CustomerController.ts
+++ b/src/modules/giving/controllers/CustomerController.ts
@@ -69,23 +69,24 @@ export class CustomerController extends GivingBaseController {
             const providerName = gw.provider?.toLowerCase();
 
             if (providerName === "kingdomfunding") {
-              // Accept Blue uses `active` as the lifecycle flag — cancelled schedules
-              // are returned with active:false. (Their `status` field stays "active"
-              // even after cancellation, so don't rely on it.)
-              if (!sub.active) continue;
+              // NMI subscriptions are normalized by the provider to { id, amount,
+              // nextRunDate, status, frequency }. NMI uses a status string rather than
+              // an `active` flag — skip clearly-inactive ones, but don't drop everything.
+              const subStatus = String(sub.status || "active").toLowerCase();
+              if (sub.active === false || ["cancelled", "canceled", "deleted", "complete", "completed"].includes(subStatus)) continue;
 
-              // Normalize Accept Blue recurring-schedule to Stripe-like format.
-              // Use next_run_date so the UI's "Start Date" column shows when the
-              // next charge will occur (more useful than schedule-creation timestamp).
-              const amountCents = Math.round((sub.amount || 0) * 100);
-              const anchorSrc = sub.next_run_date || sub.created_at;
+              // Normalize NMI recurring-schedule to the Stripe-like shape the UI expects.
+              // Prefer the next charge date so the UI's "Start Date" column is meaningful.
+              const amountCents = Math.round((Number(sub.amount) || 0) * 100);
+              const anchorSrc = sub.nextRunDate || sub.next_charge_date || sub.created_at;
+              const anchorMs = anchorSrc ? new Date(anchorSrc).getTime() : NaN;
               allSubscriptions.push({
                 id: String(sub.id),
                 status: "active",
-                billing_cycle_anchor: anchorSrc
-                  ? Math.floor(new Date(anchorSrc).getTime() / 1000)
+                billing_cycle_anchor: !isNaN(anchorMs)
+                  ? Math.floor(anchorMs / 1000)
                   : Math.floor(Date.now() / 1000),
-                default_payment_method: sub.payment_method_id ? String(sub.payment_method_id) : undefined,
+                default_payment_method: sub.customer_vault_id ? String(sub.customer_vault_id) : undefined,
                 plan: {
                   amount: amountCents,
                   interval: this.mapKFFrequencyToInterval(sub.frequency),
@@ -135,7 +136,7 @@ export class CustomerController extends GivingBaseController {
     });
   }
 
-  /** Map Accept Blue frequency names to Stripe-compatible interval names */
+  /** Map NMI/KingdomFunding frequency names to Stripe-compatible interval names */
   private mapKFFrequencyToInterval(frequency: string): string {
     switch (frequency?.toLowerCase()) {
       case "daily": return "day";

--- a/src/modules/giving/controllers/CustomerController.ts
+++ b/src/modules/giving/controllers/CustomerController.ts
@@ -10,29 +10,99 @@ export class CustomerController extends GivingBaseController {
   @httpGet("/:id/subscriptions")
   public async getSubscriptions(@requestParam("id") id: string, req: express.Request<{}, {}, null>, res: express.Response): Promise<any> {
     return this.actionWrapper(req, res, async (au) => {
-      // Subscriptions are Stripe-only currently
-      const gateway = await GatewayService.getGatewayForChurch(au.churchId, { provider: "stripe" }, this.repos.gateway).catch(() => null);
-      let permission = false;
-      if (gateway) {
-        if (au.checkAccess(Permissions.donations.viewSummary)) {
-          permission = true;
-        } else {
-          const customerData = await this.repos.customer.load(au.churchId, id);
-          if (customerData) {
-            const customer = this.repos.customer.convertToModel(au.churchId, customerData as any);
-            permission = customer.personId === au.personId;
-          }
+      // Check permissions
+      let permission = au.checkAccess(Permissions.donations.viewSummary);
+      if (!permission) {
+        const customerData = await this.repos.customer.load(au.churchId, id);
+        if (customerData) {
+          const customer = this.repos.customer.convertToModel(au.churchId, customerData as any);
+          permission = customer.personId === au.personId;
         }
       }
       if (!permission) return this.json({}, 401);
 
-      // Check if provider supports subscriptions
-      const capabilities = GatewayService.getProviderCapabilities(gateway);
-      if (!capabilities?.supportsSubscriptions) {
-        return []; // Return empty array for providers without subscription support
+      // Look up the person associated with the requested customer
+      const customerRecord = await this.repos.customer.load(au.churchId, id) as any;
+      const personId = customerRecord?.personId || au.personId;
+
+      // Load all gateways and fetch subscriptions from each that supports them
+      const allGateways = (await this.repos.gateway.loadAll(au.churchId)) as any[];
+      const allSubscriptions: any[] = [];
+
+      // If no gateways are configured, return empty array (church hasn't set up giving)
+      if (!allGateways || allGateways.length === 0) {
+        console.warn(`getSubscriptions: no gateways configured for churchId=${au.churchId}`);
+        return [];
       }
 
-      return await GatewayService.getCustomerSubscriptions(gateway, id);
+      for (const gw of allGateways) {
+        const capabilities = GatewayService.getProviderCapabilities(gw);
+        if (!capabilities?.supportsSubscriptions) continue;
+
+        try {
+          // Find the correct customer ID for this specific gateway/provider
+          let gatewayCustomerId = id; // default to the passed-in ID (works for Stripe)
+          if (gw.provider?.toLowerCase() !== "stripe") {
+            const providerCustomer = await this.repos.customer.loadByPersonAndProvider(au.churchId, personId, gw.provider) as any;
+            if (!providerCustomer) continue; // no customer on this provider, skip
+            gatewayCustomerId = providerCustomer.id;
+          }
+
+          const gateway = await GatewayService.getGatewayForChurch(au.churchId, { gatewayId: gw.id }, this.repos.gateway);
+
+          let result: any;
+          try {
+            result = await GatewayService.getCustomerSubscriptions(gateway, gatewayCustomerId);
+          } catch (subErr: any) {
+            // Customer doesn't exist on the provider — skip this gateway
+            if (subErr.response?.status === 404) {
+              console.warn(`Customer ${gatewayCustomerId} not found on ${gw.provider} for subscriptions, skipping.`);
+              continue;
+            }
+            throw subErr;
+          }
+
+          // Handle Stripe format ({ data: [...] }) and KF format (array)
+          const subs = Array.isArray(result) ? result : (result?.data || []);
+
+          for (const sub of subs) {
+            const providerName = gw.provider?.toLowerCase();
+
+            if (providerName === "kingdomfunding") {
+              // Skip inactive/canceled schedules
+              if (!sub.active) continue;
+
+              // Normalize Accept Blue recurring-schedule to Stripe-like format.
+              // Use next_run_date so the UI's "Start Date" column shows when the
+              // next charge will occur (more useful than schedule-creation timestamp).
+              const amountCents = Math.round((sub.amount || 0) * 100);
+              const anchorSrc = sub.next_run_date || sub.created_at;
+              allSubscriptions.push({
+                id: String(sub.id),
+                status: "active",
+                billing_cycle_anchor: anchorSrc
+                  ? Math.floor(new Date(anchorSrc).getTime() / 1000)
+                  : Math.floor(Date.now() / 1000),
+                default_payment_method: sub.payment_method_id ? String(sub.payment_method_id) : undefined,
+                plan: {
+                  amount: amountCents,
+                  interval: this.mapKFFrequencyToInterval(sub.frequency),
+                  interval_count: 1,
+                },
+                provider: providerName,
+                gatewayId: gw.id,
+              });
+            } else {
+              allSubscriptions.push({ ...sub, provider: providerName, gatewayId: gw.id });
+            }
+          }
+        } catch (e) {
+          console.warn(`Failed to load subscriptions from ${gw.provider}:`, e);
+        }
+      }
+
+      // Return in { data: [...] } format for frontend compatibility
+      return { data: allSubscriptions };
     });
   }
 
@@ -61,5 +131,20 @@ export class CustomerController extends GivingBaseController {
       await this.repos.customer.delete(au.churchId, id);
       return {};
     });
+  }
+
+  /** Map Accept Blue frequency names to Stripe-compatible interval names */
+  private mapKFFrequencyToInterval(frequency: string): string {
+    switch (frequency?.toLowerCase()) {
+      case "daily": return "day";
+      case "weekly": return "week";
+      case "biweekly": return "week"; // 2 weeks — interval_count would be 2
+      case "monthly": return "month";
+      case "bimonthly": return "month"; // 2 months
+      case "quarterly": return "month"; // 3 months
+      case "biannually": return "month"; // 6 months
+      case "annually": return "year";
+      default: return "month";
+    }
   }
 }

--- a/src/modules/giving/controllers/CustomerController.ts
+++ b/src/modules/giving/controllers/CustomerController.ts
@@ -69,7 +69,9 @@ export class CustomerController extends GivingBaseController {
             const providerName = gw.provider?.toLowerCase();
 
             if (providerName === "kingdomfunding") {
-              // Skip inactive/canceled schedules
+              // Accept Blue uses `active` as the lifecycle flag — cancelled schedules
+              // are returned with active:false. (Their `status` field stays "active"
+              // even after cancellation, so don't rely on it.)
               if (!sub.active) continue;
 
               // Normalize Accept Blue recurring-schedule to Stripe-like format.

--- a/src/modules/giving/controllers/DonateController.ts
+++ b/src/modules/giving/controllers/DonateController.ts
@@ -25,14 +25,26 @@ export class DonateController extends GivingBaseController {
       const gateways = (await this.repos.gateway.loadAll(churchId)) as any[];
 
       // Return gateway info without sensitive data
-      const publicGateways = gateways.map(gateway => ({
-        id: gateway.id,
-        provider: gateway.provider,
-        publicKey: gateway.publicKey,
-        productId: gateway.productId,
-        payFees: gateway.payFees,
-        currency: gateway.currency
-      }));
+      const publicGateways = gateways.map(gateway => {
+        const base: any = {
+          id: gateway.id,
+          provider: gateway.provider,
+          publicKey: gateway.publicKey,
+          productId: gateway.productId,
+          payFees: gateway.payFees,
+          currency: gateway.currency,
+          enabled: gateway.enabled,
+          environment: gateway.environment || null
+        };
+        // Include non-sensitive settings for frontend (e.g. sandbox flag)
+        if (gateway.settings) {
+          try {
+            const settings = typeof gateway.settings === "string" ? JSON.parse(gateway.settings) : gateway.settings;
+            base.settings = { sandbox: settings.sandbox || false };
+          } catch { /* ignore parse errors */ }
+        }
+        return base;
+      });
 
       return { gateways: publicGateways };
     });
@@ -170,24 +182,45 @@ export class DonateController extends GivingBaseController {
           if (this.shouldProcessDonation(provider, webhookResult.eventType!)) {
             const isPending = this.isPendingPayment(provider, webhookResult.eventType!);
             const isCompleted = this.isCompletedPayment(provider, webhookResult.eventType!);
-            const transactionId = webhookResult.eventData?.id;
+            // KingdomFunding puts the transaction ID at reference_number or transaction.id, not at the top-level id
+            const transactionId = webhookResult.eventData?.id
+              || webhookResult.eventData?.reference_number?.toString()
+              || webhookResult.eventData?.transaction?.id?.toString();
+
+            // Idempotency: always check for an existing donation by transactionId before creating.
+            // This protects against:
+            //   - Same webhook delivered twice (Cloud Tasks retries with same body.id are caught
+            //     by eventLog dedup above; retries with new delivery IDs are caught here)
+            //   - Multiple status webhooks for the same transaction (e.g., ACH succeeded then settled)
+            //   - The /donate/charge endpoint already logging the donation immediately, then the
+            //     async webhook arriving later
+            const existingDonation = transactionId
+              ? await this.repos.donation.loadByTransactionId(churchId, transactionId)
+              : null;
 
             if (isCompleted && transactionId) {
-              // Check if a pending donation already exists for this transaction
-              const existingDonation = await this.repos.donation.loadByTransactionId(churchId, transactionId);
               if (existingDonation) {
-                // Update existing pending donation to complete
+                // Update existing pending/in-flight donation to complete
                 await GatewayService.updateDonationStatus(gateway, churchId, transactionId, "complete", this.repos);
               } else {
-                // No pending donation found, create a new complete donation
+                // No prior donation found, create a new complete donation
                 await GatewayService.logDonation(gateway, churchId, webhookResult.eventData, this.repos, "complete");
               }
             } else if (isPending) {
-              // Create a new pending donation for ACH payments
-              await GatewayService.logDonation(gateway, churchId, webhookResult.eventData, this.repos, "pending");
+              if (existingDonation) {
+                // Pending webhook for a transaction we already know about — no-op
+                console.log(`KingdomFunding webhook: skipping duplicate pending event for txnId=${transactionId}`);
+              } else {
+                // Create a new pending donation for ACH payments awaiting settlement
+                await GatewayService.logDonation(gateway, churchId, webhookResult.eventData, this.repos, "pending");
+              }
             } else {
               // Regular completed donation (card payments, etc.)
-              await GatewayService.logDonation(gateway, churchId, webhookResult.eventData, this.repos, "complete");
+              if (existingDonation && transactionId) {
+                await GatewayService.updateDonationStatus(gateway, churchId, transactionId, "complete", this.repos);
+              } else {
+                await GatewayService.logDonation(gateway, churchId, webhookResult.eventData, this.repos, "complete");
+              }
             }
           } else if (this.shouldCancelSubscription(provider, webhookResult.eventType!)) {
             await this.repos.subscription.delete(churchId, webhookResult.eventData.id);
@@ -203,29 +236,38 @@ export class DonateController extends GivingBaseController {
   }
 
   private shouldProcessDonation(provider: string, eventType: string): boolean {
-    const donationEvents = {
+    const donationEvents: Record<string, string[]> = {
       // payment_intent.processing is for ACH payments that are pending
       // payment_intent.succeeded is the new standard for ACH payments via Payment Intents API
       // charge.succeeded is kept for backward compatibility during migration
       stripe: ["charge.succeeded", "invoice.paid", "payment_intent.succeeded", "payment_intent.processing"],
-      paypal: ["PAYMENT.CAPTURE.COMPLETED"]
+      paypal: ["PAYMENT.CAPTURE.COMPLETED"],
+      // KingdomFunding webhook events: "succeeded.charge" for card/ACH, "status.settled" for ACH settlement
+      kingdomfunding: ["succeeded.charge", "status.settled"],
     };
-    return donationEvents[provider as keyof typeof donationEvents]?.includes(eventType) || false;
+    return donationEvents[provider]?.includes(eventType) || false;
   }
 
   private isPendingPayment(provider: string, eventType: string): boolean {
-    // ACH payments start in "processing" state and later transition to "succeeded"
-    return provider === "stripe" && eventType === "payment_intent.processing";
+    // ACH payments start in "processing" state and later transition to "succeeded"/"settled"
+    if (provider === "stripe") return eventType === "payment_intent.processing";
+    // KingdomFunding ACH: initial charge succeeds but needs settlement confirmation
+    if (provider === "kingdomfunding") return eventType === "status.originated" || eventType === "status.pending";
+    return false;
   }
 
   private isCompletedPayment(provider: string, eventType: string): boolean {
-    // Check if this is a payment completion event (for updating pending -> complete)
-    return provider === "stripe" && eventType === "payment_intent.succeeded";
+    if (provider === "stripe") return eventType === "payment_intent.succeeded";
+    if (provider === "kingdomfunding") return eventType === "status.settled" || eventType === "succeeded.charge";
+    return false;
   }
 
   private shouldCancelSubscription(provider: string, eventType: string): boolean {
-    const cancellationEvents = { stripe: ["customer.subscription.deleted"], paypal: ["BILLING.SUBSCRIPTION.CANCELLED"] };
-    return cancellationEvents[provider as keyof typeof cancellationEvents]?.includes(eventType) || false;
+    const cancellationEvents: Record<string, string[]> = {
+      stripe: ["customer.subscription.deleted"],
+      paypal: ["BILLING.SUBSCRIPTION.CANCELLED"],
+    };
+    return cancellationEvents[provider]?.includes(eventType) || false;
   }
 
   @httpPost("/replay-stripe-events")
@@ -269,7 +311,6 @@ export class DonateController extends GivingBaseController {
           eventId: string;
           type: string;
           amount: number;
-          currency: string;
           created: Date;
           customer: string;
           status: "new" | "already_imported" | "imported" | "skipped" | "error";
@@ -278,7 +319,6 @@ export class DonateController extends GivingBaseController {
 
         for (const event of events) {
           const eventData = event.data.object as any;
-          const eventCurrency = (eventData.currency || stripeGateway.currency || "usd").toString().toLowerCase();
 
           // Skip subscription events (they're handled separately)
           const isSubscriptionEvent = eventData.subscription || eventData.description?.toLowerCase().includes("subscription");
@@ -287,7 +327,6 @@ export class DonateController extends GivingBaseController {
               eventId: event.id,
               type: event.type,
               amount: (eventData.amount || eventData.amount_paid || 0) / 100,
-              currency: eventCurrency,
               created: new Date(event.created * 1000),
               customer: eventData.customer || "",
               status: "skipped",
@@ -304,7 +343,6 @@ export class DonateController extends GivingBaseController {
               eventId: event.id,
               type: event.type,
               amount: (eventData.amount || eventData.amount_paid || 0) / 100,
-              currency: eventCurrency,
               created: new Date(event.created * 1000),
               customer: eventData.customer || "",
               status: "already_imported"
@@ -325,7 +363,6 @@ export class DonateController extends GivingBaseController {
               eventId: event.id,
               type: event.type,
               amount,
-              currency: eventCurrency,
               created: donationDate,
               customer: eventData.customer || "",
               status: "already_imported",
@@ -339,7 +376,6 @@ export class DonateController extends GivingBaseController {
               eventId: event.id,
               type: event.type,
               amount,
-              currency: eventCurrency,
               created: donationDate,
               customer: eventData.customer || "",
               status: "new"
@@ -354,7 +390,6 @@ export class DonateController extends GivingBaseController {
                 eventId: event.id,
                 type: event.type,
                 amount,
-                currency: eventCurrency,
                 created: donationDate,
                 customer: eventData.customer || "",
                 status: "imported"
@@ -364,7 +399,6 @@ export class DonateController extends GivingBaseController {
                 eventId: event.id,
                 type: event.type,
                 amount,
-                currency: eventCurrency,
                 created: donationDate,
                 customer: eventData.customer || "",
                 status: "error",
@@ -410,19 +444,134 @@ export class DonateController extends GivingBaseController {
       donationData.currency = normalizedCurrency;
 
       try {
+        // KingdomFunding + saveCard: create customer & payment method BEFORE charging,
+        // then charge with the saved pm-{id} instead of the single-use nonce.
+        // Flow: Create customer → Add payment method (nonce) → Charge with pm-{id}
+        // Uses GatewayService (not direct Axios) so credentials are decrypted and URLs are correct.
+        if (donationData.saveCard && gateway.provider?.toLowerCase() === "kingdomfunding") {
+          try {
+            const personEmail = donationData.person?.email || "";
+            const personName = donationData.person?.name || donationData.name || "";
+            const personId = donationData.person?.id;
+
+            // Step 1: Find or create customer via GatewayService
+            let customerId: string | undefined;
+            if (personId) {
+              const existingCustomer = await this.repos.customer.loadByPersonAndProvider(churchId, personId, "kingdomfunding") as any;
+              if (existingCustomer) customerId = existingCustomer.id;
+            }
+            if (!customerId) {
+              customerId = await GatewayService.createCustomer(gateway, personEmail, personName);
+              if (customerId && personId) {
+                await this.repos.customer.save({ id: customerId, churchId, personId, provider: "kingdomfunding" });
+              }
+            }
+
+            if (customerId) {
+              // Step 2: Attach payment method using nonce via GatewayService
+              const nonceToken = donationData.token || donationData.id || "";
+              const nonceSource = nonceToken.startsWith("nonce-") ? nonceToken : `nonce-${nonceToken}`;
+
+              const attachOptions: any = {
+                customerId,
+                source: nonceSource,
+                name: personName,
+              };
+              if (donationData.expiry_month) attachOptions.expiry_month = Number(donationData.expiry_month);
+              if (donationData.expiry_year) {
+                let ey = Number(donationData.expiry_year);
+                if (ey > 0 && ey < 100) ey += 2000;
+                attachOptions.expiry_year = ey;
+              }
+
+              let pm: any;
+              try {
+                pm = await GatewayService.attachPaymentMethod(gateway, nonceSource, attachOptions);
+              } catch (attachErr: any) {
+                // Customer doesn't exist on provider (stale local record) — recreate and retry
+                const status = attachErr.response?.status || attachErr.statusCode;
+                if (status === 404) {
+                  console.log(`Customer ${customerId} not found on Accept Blue, recreating...`);
+                  customerId = await GatewayService.createCustomer(gateway, personEmail, personName);
+                  if (customerId && personId) {
+                    await this.repos.customer.save({ id: customerId, churchId, personId, provider: "kingdomfunding" });
+                  }
+                  if (customerId) {
+                    attachOptions.customerId = customerId;
+                    pm = await GatewayService.attachPaymentMethod(gateway, nonceSource, attachOptions);
+                  } else {
+                    throw attachErr;
+                  }
+                } else {
+                  throw attachErr;
+                }
+              }
+
+              const savedPmId = pm?.id;
+              if (savedPmId) {
+                // Save payment method locally
+                const cardType = pm.card_type || donationData.cardBrand || "Card";
+                const last4 = pm.last_4 || donationData.cardLast4 || "";
+                await this.repos.gatewayPaymentMethod.save({
+                  churchId, gatewayId: gateway.id, customerId,
+                  externalId: String(savedPmId),
+                  methodType: donationData.type === "check" ? "bank" : "card",
+                  displayName: `${cardType} ****${last4}`,
+                  metadata: { card_type: cardType, last_4: last4 }
+                } as any);
+
+                // Step 3: Charge using the saved payment method instead of the nonce
+                donationData.paymentMethodId = String(savedPmId);
+                donationData.customerId = customerId;
+                delete donationData.id;     // Remove nonce so processCharge uses pm-{id}
+                delete donationData.token;
+              }
+            }
+          } catch (saveCardErr: any) {
+            console.warn("Charge: Failed to save card before charge (non-fatal, charging with nonce):", saveCardErr.response?.data || saveCardErr.message);
+            // Fall through — charge will proceed with original nonce
+          }
+        }
+
+        // KF saved payment method: the frontend sends id="54879" (a numeric PM ID from Accept Blue).
+        // The KF provider treats id as a nonce (nonce-54879) which is wrong.
+        // Detect numeric IDs and move them to paymentMethodId so the provider uses pm-{id} instead.
+        if (gateway.provider?.toLowerCase() === "kingdomfunding" && donationData.id && !donationData.paymentMethodId) {
+          const id = String(donationData.id);
+          if (/^\d+$/.test(id)) {
+            donationData.paymentMethodId = id;
+            delete donationData.id;
+          }
+        }
+
         const chargeResult = await GatewayService.processCharge(gateway, donationData);
 
         if (!chargeResult.success) {
-          return this.json({ error: chargeResult.error || "Charge processing failed" }, 400);
+          return this.json({ error: chargeResult.data?.error || chargeResult.error || "Charge processing failed" }, 400);
         }
 
-        // For PayPal, we need to log the events since it's captured immediately
-        if (gateway.provider === "paypal") {
-          await GatewayService.logEvent(gateway, churchId, chargeResult.data, chargeResult.data, this.repos);
-          await GatewayService.logDonation(gateway, churchId, chargeResult.data, this.repos);
+        // For PayPal and KingdomFunding, log the donation immediately (no webhook flow)
+        if (gateway.provider === "paypal" || gateway.provider?.toLowerCase() === "kingdomfunding") {
+          try {
+            await GatewayService.logEvent(gateway, churchId, chargeResult.data, chargeResult.data, this.repos);
+            const logData = {
+              ...chargeResult.data,
+              amount: donationData.amount,
+              funds: donationData.funds,
+              person: donationData.person,
+              notes: donationData.notes,
+            };
+            await GatewayService.logDonation(gateway, churchId, logData, this.repos, "complete");
+          } catch (logErr: any) {
+            console.error("Charge: Failed to log donation:", logErr?.message || logErr, logErr?.stack);
+          }
         }
 
-        await this.sendEmails(donationData.person.email, donationData?.church, donationData.funds, donationData?.amount, donationData?.interval, donationData?.billing_cycle_anchor, "one-time", normalizedCurrency);
+        try {
+          await this.sendEmails(donationData.person.email, donationData?.church, donationData.funds, donationData?.amount, donationData?.interval, donationData?.billing_cycle_anchor, "one-time");
+        } catch (emailErr) {
+          console.warn("Charge: Failed to send confirmation email (non-fatal)", emailErr);
+        }
 
         return { ...chargeResult.data, provider: gateway.provider };
       } catch (error) {
@@ -435,7 +584,7 @@ export class DonateController extends GivingBaseController {
   @httpPost("/subscribe")
   public async subscribe(req: express.Request<any>, res: express.Response): Promise<any> {
     return this.actionWrapper(req, res, async (au) => {
-      const { id, amount, customerId, type, billing_cycle_anchor, proration_behavior, interval, funds, person, notes, churchId: CHURCH_ID, provider, gatewayId, currency } = req.body;
+      const { id, amount, customerId, type, billing_cycle_anchor, proration_behavior, interval, funds, person, notes, churchId: CHURCH_ID, provider, gatewayId, currency, expiry_month, expiry_year, routing_number, account_number, account_type, sec_code, name: bankName } = req.body;
       const churchId = au.churchId || CHURCH_ID;
 
       // Validate required parameters
@@ -465,8 +614,24 @@ export class DonateController extends GivingBaseController {
           billing_cycle_anchor,
           proration_behavior,
           interval,
-          notes
+          notes,
+          person,
+          name: bankName || person?.name?.display || person?.name || "",
+          email: person?.email || "",
+          expiry_month,
+          expiry_year,
+          // ACH/bank fields for KingdomFunding recurring donations
+          routing_number,
+          account_number,
+          account_type,
+          sec_code,
         };
+
+        // For KF: pass existing local customer ID so provider can reuse it
+        if (gateway.provider?.toLowerCase() === "kingdomfunding" && person?.id && !subscriptionData.customerId) {
+          const existingKFCustomer = await this.repos.customer.loadByPersonAndProvider(churchId, person.id, "kingdomfunding") as any;
+          if (existingKFCustomer?.id) subscriptionData.customerId = existingKFCustomer.id;
+        }
 
         const subscriptionResult = await GatewayService.createSubscription(gateway, subscriptionData);
 
@@ -474,13 +639,19 @@ export class DonateController extends GivingBaseController {
           return this.json({ error: "Subscription creation failed" }, 400);
         }
 
+        // Save the KF customer ID locally (created during subscription on Accept Blue)
+        const abCustomerId = subscriptionResult.data?.customerId ? String(subscriptionResult.data.customerId) : customerId;
+        if (gateway.provider?.toLowerCase() === "kingdomfunding" && abCustomerId && person?.id) {
+          try {
+            await this.repos.customer.save({ id: abCustomerId, churchId, personId: person.id, provider: "kingdomfunding" });
+          } catch (_e) { /* customer may already exist, ignore */ }
+        }
+
         const subscription: Subscription = {
           id: subscriptionResult.subscriptionId,
           churchId,
           personId: person.id,
-          customerId,
-          gatewayId: gateway.id,
-          currency: normalizedCurrency
+          customerId: abCustomerId || customerId,
         };
 
         await this.repos.subscription.save(subscription);
@@ -497,9 +668,16 @@ export class DonateController extends GivingBaseController {
         });
 
         await Promise.all(promises);
-        await this.sendEmails(person.email, req.body?.church, funds, amount, interval, billing_cycle_anchor, "recurring", normalizedCurrency);
 
-        return { ...subscriptionResult.data, provider: gateway.provider };
+        try {
+          await this.sendEmails(person.email, req.body?.church, funds, amount, interval, billing_cycle_anchor, "recurring");
+        } catch (emailErr) {
+          console.warn("Subscribe: Failed to send confirmation email (non-fatal)", emailErr);
+        }
+
+        // Normalize status for frontend compatibility
+        const normalizedStatus = (subscriptionResult.data?.status || "active").toLowerCase();
+        return { ...subscriptionResult.data, provider: gateway.provider, status: normalizedStatus };
       } catch (error) {
         console.error("Subscription creation failed:", error);
         return this.json({ error: "Subscription creation failed" }, 500);
@@ -530,8 +708,7 @@ export class DonateController extends GivingBaseController {
             return this.json({ error: "Gateway not found" }, 404);
           }
 
-          const paymentType = type === "ach" ? "bank" as const : "card" as const;
-          calculatedFee = await GatewayService.calculateFees(gateway, amount, churchId, currencyToUse, paymentType);
+          calculatedFee = await GatewayService.calculateFees(gateway, amount, churchId, currencyToUse);
           gatewayProvider = gateway.provider;
         } else {
           // Legacy type-based calculation for backward compatibility
@@ -557,32 +734,27 @@ export class DonateController extends GivingBaseController {
     amount?: number,
     interval?: { interval_count: number; interval: string },
     billingCycleAnchor?: number,
-    donationType: "recurring" | "one-time" = "recurring",
-    currency: string = "USD"
+    donationType: "recurring" | "one-time" = "recurring"
   ) => {
     // Skip email if no recipient address
     if (!to) return;
 
     const contentRows: any[] = [];
     let totalFundAmount = 0;
-    const currencyCode = (currency || "USD").toUpperCase();
 
     funds.forEach((fund, index) => {
       totalFundAmount += fund.amount;
-      const formattedFund = CurrencyHelper.formatCurrencyWithLocale(fund.amount, currencyCode);
       if (donationType === "recurring") {
         const startDate = dayjs(billingCycleAnchor).format("MMM D, YYYY");
         contentRows.push(
-          `<tr>${index === 0 ? `<td style="font-size: 15px" rowspan="${funds.length}">${interval!.interval_count} ${interval!.interval}<BR><span style="font-size: 13px">(from ${startDate})</span></td>` : ""}<td style="font-size: 15px; text-overflow: ellipsis; overflow: hidden;">${fund.name}</td><td style="font-size: 15px">${formattedFund}</td></tr>`
+          `<tr>${index === 0 ? `<td style="font-size: 15px" rowspan="${funds.length}">${interval!.interval_count} ${interval!.interval}<BR><span style="font-size: 13px">(from ${startDate})</span></td>` : ""}<td style="font-size: 15px; text-overflow: ellipsis; overflow: hidden;">${fund.name}</td><td style="font-size: 15px">$${fund.amount}</td></tr>`
         );
       } else {
-        contentRows.push(`<tr><td style="font-size: 15px; text-overflow: ellipsis; overflow: hidden;">${fund.name}</td><td style="font-size: 15px">${formattedFund}</td></tr>`);
+        contentRows.push(`<tr><td style="font-size: 15px; text-overflow: ellipsis; overflow: hidden;">${fund.name}</td><td style="font-size: 15px">$${fund.amount}</td></tr>`);
       }
     });
 
     const transactionFee = amount! - totalFundAmount;
-    const formattedFee = CurrencyHelper.formatCurrencyWithLocale(transactionFee, currencyCode);
-    const formattedTotal = CurrencyHelper.formatCurrencyWithLocale(amount || 0, currencyCode);
 
     const domain = Environment.appEnv === "staging" ? `${church.subDomain}.staging.b1.church` : `${church.subDomain}.b1.church`;
 
@@ -606,12 +778,12 @@ export class DonateController extends GivingBaseController {
             <tr style="border-top: solid #dee2e6 1px">
               <td></td>
               <th style="font-size: 15px">Transaction Fee</th>
-              <td>${formattedFee}</td>
+              <td>$${CurrencyHelper.formatCurrency(transactionFee)}</td>
             </tr>
             <tr style="border-top: solid #dee2e6 1px">
               <td></td>
               <th style="font-size: 15px">Total</th>
-              <td>${formattedTotal}</td>
+              <td>$${amount}</td>
             </tr>
           `
       }
@@ -638,11 +810,11 @@ export class DonateController extends GivingBaseController {
           : `
             <tr style="border-top: solid #dee2e6 1px">
               <th style="font-size: 15px">Transaction Fee</th>
-              <td>${formattedFee}</td>
+              <td>$${CurrencyHelper.formatCurrency(transactionFee)}</td>
             </tr>
             <tr style="border-top: solid #dee2e6 1px">
               <th style="font-size: 15px">Total</th>
-              <td>${formattedTotal}</td>
+              <td>$${amount}</td>
             </tr>
           `
       }
@@ -700,7 +872,7 @@ export class DonateController extends GivingBaseController {
     const gateways = (await this.repos.gateway.loadAll(churchId)) as any[];
     const stripeGateway = gateways.find((g) => g.provider.toLowerCase() === "stripe");
     if (stripeGateway) {
-      return await GatewayService.calculateFees(stripeGateway, amount, churchId, undefined, "bank");
+      return await GatewayService.calculateFees(stripeGateway, amount, churchId);
     }
 
     // Fallback to hardcoded calculation if no Stripe gateway found
@@ -722,6 +894,10 @@ export class DonateController extends GivingBaseController {
   public async captchaVerify(req: express.Request<{}, {}, { token: string }>, res: express.Response): Promise<any> {
     return this.actionWrapperAnon(req, res, async () => {
       try {
+        // In dev mode, always return human to speed up testing
+        if (Environment.currentEnvironment === "dev") {
+          return { response: "human" };
+        }
         // detecting if its a bot or a human
         const { token } = req.body;
         const response = await Axios.post(`https://www.google.com/recaptcha/api/siteverify?secret=${Environment.googleRecaptchaSecretKey}&response=${token}`);
@@ -755,6 +931,7 @@ export class DonateController extends GivingBaseController {
       }
     });
   }
+
 
   /**
    * Get gateway by provider name or ID using the centralized helper

--- a/src/modules/giving/controllers/DonateController.ts
+++ b/src/modules/giving/controllers/DonateController.ts
@@ -236,14 +236,21 @@ export class DonateController extends GivingBaseController {
   }
 
   private shouldProcessDonation(provider: string, eventType: string): boolean {
+    // KingdomFunding/NMI event types: transaction.<action>.<result> for cards/ACH sales,
+    // and check.* events for the ACH settlement lifecycle.
+    if (provider === "kingdomfunding") {
+      return (
+        eventType === "transaction.sale.success" ||
+        eventType === "transaction.auth.success" ||
+        eventType.startsWith("check.") // ACH status lifecycle (settled/returned/etc.)
+      );
+    }
     const donationEvents: Record<string, string[]> = {
       // payment_intent.processing is for ACH payments that are pending
       // payment_intent.succeeded is the new standard for ACH payments via Payment Intents API
       // charge.succeeded is kept for backward compatibility during migration
       stripe: ["charge.succeeded", "invoice.paid", "payment_intent.succeeded", "payment_intent.processing"],
       paypal: ["PAYMENT.CAPTURE.COMPLETED"],
-      // KingdomFunding webhook events: "succeeded.charge" for card/ACH, "status.settled" for ACH settlement
-      kingdomfunding: ["succeeded.charge", "status.settled"],
     };
     return donationEvents[provider]?.includes(eventType) || false;
   }
@@ -251,14 +258,21 @@ export class DonateController extends GivingBaseController {
   private isPendingPayment(provider: string, eventType: string): boolean {
     // ACH payments start in "processing" state and later transition to "succeeded"/"settled"
     if (provider === "stripe") return eventType === "payment_intent.processing";
-    // KingdomFunding ACH: initial charge succeeds but needs settlement confirmation
-    if (provider === "kingdomfunding") return eventType === "status.originated" || eventType === "status.pending";
+    // KingdomFunding/NMI ACH: the check.* lifecycle starts pending/originated before settling.
+    if (provider === "kingdomfunding") return /^check\.(status\.)?(pending|originated|processing)/.test(eventType);
     return false;
   }
 
   private isCompletedPayment(provider: string, eventType: string): boolean {
     if (provider === "stripe") return eventType === "payment_intent.succeeded";
-    if (provider === "kingdomfunding") return eventType === "status.settled" || eventType === "succeeded.charge";
+    // NMI: card/ACH sale success, or the ACH check lifecycle reaching "settled".
+    if (provider === "kingdomfunding") {
+      return (
+        eventType === "transaction.sale.success" ||
+        eventType === "transaction.auth.success" ||
+        /^check\.(status\.)?settled/.test(eventType)
+      );
+    }
     return false;
   }
 
@@ -444,9 +458,9 @@ export class DonateController extends GivingBaseController {
       donationData.currency = normalizedCurrency;
 
       try {
-        // KingdomFunding + saveCard: create customer & payment method BEFORE charging,
-        // then charge with the saved pm-{id} instead of the single-use nonce.
-        // Flow: Create customer → Add payment method (nonce) → Charge with pm-{id}
+        // KingdomFunding (NMI) + saveCard: vault the payment method BEFORE charging,
+        // then charge the saved Customer Vault record instead of the single-use token.
+        // Flow: Create customer → Vault payment method (payment_token) → Charge by vault id.
         // Uses GatewayService (not direct Axios) so credentials are decrypted and URLs are correct.
         if (donationData.saveCard && gateway.provider?.toLowerCase() === "kingdomfunding") {
           try {
@@ -468,13 +482,13 @@ export class DonateController extends GivingBaseController {
             }
 
             if (customerId) {
-              // Step 2: Attach payment method using nonce via GatewayService
-              const nonceToken = donationData.token || donationData.id || "";
-              const nonceSource = nonceToken.startsWith("nonce-") ? nonceToken : `nonce-${nonceToken}`;
+              // Step 2: Vault the payment method using the raw NMI payment_token.
+              // (NMI tokens carry no "nonce-" prefix — that was an Accept Blue convention.)
+              const paymentToken = donationData.token || donationData.id || "";
 
               const attachOptions: any = {
                 customerId,
-                source: nonceSource,
+                source: paymentToken,
                 name: personName,
               };
               if (donationData.expiry_month) attachOptions.expiry_month = Number(donationData.expiry_month);
@@ -486,19 +500,19 @@ export class DonateController extends GivingBaseController {
 
               let pm: any;
               try {
-                pm = await GatewayService.attachPaymentMethod(gateway, nonceSource, attachOptions);
+                pm = await GatewayService.attachPaymentMethod(gateway, paymentToken, attachOptions);
               } catch (attachErr: any) {
                 // Customer doesn't exist on provider (stale local record) — recreate and retry
                 const status = attachErr.response?.status || attachErr.statusCode;
                 if (status === 404) {
-                  console.log(`Customer ${customerId} not found on Accept Blue, recreating...`);
+                  console.log(`Customer ${customerId} not found on NMI, recreating...`);
                   customerId = await GatewayService.createCustomer(gateway, personEmail, personName);
                   if (customerId && personId) {
                     await this.repos.customer.save({ id: customerId, churchId, personId, provider: "kingdomfunding" });
                   }
                   if (customerId) {
                     attachOptions.customerId = customerId;
-                    pm = await GatewayService.attachPaymentMethod(gateway, nonceSource, attachOptions);
+                    pm = await GatewayService.attachPaymentMethod(gateway, paymentToken, attachOptions);
                   } else {
                     throw attachErr;
                   }
@@ -520,25 +534,26 @@ export class DonateController extends GivingBaseController {
                   metadata: { card_type: cardType, last_4: last4 }
                 } as any);
 
-                // Step 3: Charge using the saved payment method instead of the nonce
+                // Step 3: Charge the saved Customer Vault record instead of the one-time token.
                 donationData.paymentMethodId = String(savedPmId);
                 donationData.customerId = customerId;
-                delete donationData.id;     // Remove nonce so processCharge uses pm-{id}
+                delete donationData.id;     // Remove the token so processCharge uses the vault id
                 delete donationData.token;
               }
             }
           } catch (saveCardErr: any) {
-            console.warn("Charge: Failed to save card before charge (non-fatal, charging with nonce):", saveCardErr.response?.data || saveCardErr.message);
-            // Fall through — charge will proceed with original nonce
+            console.warn("Charge: Failed to vault payment method before charge (non-fatal, charging with one-time token):", saveCardErr.response?.data || saveCardErr.message);
+            // Fall through — charge will proceed with the original one-time token
           }
         }
 
-        // KF saved payment method: the frontend sends id="54879" (a numeric PM ID from Accept Blue).
-        // The KF provider treats id as a nonce (nonce-54879) which is wrong.
-        // Detect numeric IDs and move them to paymentMethodId so the provider uses pm-{id} instead.
+        // KF saved payment method: for a saved method the frontend sends `id` = the stored
+        // Customer Vault id (a UUID), not a fresh Collect.js token. Move it to paymentMethodId
+        // so the provider charges by customer_vault_id instead of mistaking it for a payment_token.
         if (gateway.provider?.toLowerCase() === "kingdomfunding" && donationData.id && !donationData.paymentMethodId) {
           const id = String(donationData.id);
-          if (/^\d+$/.test(id)) {
+          const isVaultId = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(id) || /^\d+$/.test(id);
+          if (isVaultId) {
             donationData.paymentMethodId = id;
             delete donationData.id;
           }
@@ -560,6 +575,9 @@ export class DonateController extends GivingBaseController {
               funds: donationData.funds,
               person: donationData.person,
               notes: donationData.notes,
+              // Carry the payment type so ACH charges are labeled correctly — NMI's
+              // token-sale response doesn't echo bank details to infer it from.
+              paymentType: donationData.type,
             };
             await GatewayService.logDonation(gateway, churchId, logData, this.repos, "complete");
           } catch (logErr: any) {
@@ -639,7 +657,7 @@ export class DonateController extends GivingBaseController {
           return this.json({ error: "Subscription creation failed" }, 400);
         }
 
-        // Save the KF customer ID locally (created during subscription on Accept Blue)
+        // Save the KF customer ID locally (the NMI Customer Vault id created during subscription)
         const abCustomerId = subscriptionResult.data?.customerId ? String(subscriptionResult.data.customerId) : customerId;
         if (gateway.provider?.toLowerCase() === "kingdomfunding" && abCustomerId && person?.id) {
           try {

--- a/src/modules/giving/controllers/PaymentMethodController.ts
+++ b/src/modules/giving/controllers/PaymentMethodController.ts
@@ -638,8 +638,8 @@ export class PaymentMethodController extends GivingBaseController {
         if (localRecord) {
           const gw = (await this.repos.gateway.loadAll(au.churchId) as any[]).find(g => g.id === localRecord.gatewayId);
           resolvedProvider = gw?.provider?.toLowerCase() || "paypal";
-        } else if (/^\d+$/.test(id)) {
-          // Numeric IDs are Accept Blue / KingdomFunding payment method IDs
+        } else if (/^\d+$/.test(id) || /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(id)) {
+          // KingdomFunding (NMI) Customer Vault ids — UUIDs (or legacy numeric ids)
           resolvedProvider = "kingdomfunding";
         } else {
           resolvedProvider = "paypal"; // fallback for backward compat
@@ -681,7 +681,14 @@ export class PaymentMethodController extends GivingBaseController {
               const provider = GatewayFactory.getProvider(gateway.provider);
               const config = GatewayService.getGatewayConfig(gateway);
               const schedules = await (provider as any).getCustomerSubscriptions(config, customerId);
-              const activeSchedules = (schedules || []).filter((s: any) => s.payment_method_id?.toString() === id && s.active !== false);
+              // NMI ties a schedule to the saved method via customer_vault_id; status is a
+              // string (no `active` flag), so treat anything not clearly inactive as active.
+              const activeSchedules = (schedules || []).filter((s: any) => {
+                const matchesMethod = s.customer_vault_id?.toString() === id || s.payment_method_id?.toString() === id;
+                const status = String(s.status || "active").toLowerCase();
+                const isActive = s.active !== false && !["cancelled", "canceled", "deleted", "complete", "completed"].includes(status);
+                return matchesMethod && isActive;
+              });
               for (const schedule of activeSchedules) {
                 try {
                   await provider.cancelSubscription(config, schedule.id.toString());
@@ -692,7 +699,7 @@ export class PaymentMethodController extends GivingBaseController {
               }
               await GatewayService.detachPaymentMethod(gateway, id);
             } catch (retryErr: any) {
-              // Could not delete from Accept Blue — proceed to clean up locally only
+              // Could not delete from NMI — proceed to clean up locally only
               console.warn("[PM Delete] Could not delete PM from provider, cleaning up local records only:", retryErr?.message || retryErr);
             }
           } else {

--- a/src/modules/giving/controllers/PaymentMethodController.ts
+++ b/src/modules/giving/controllers/PaymentMethodController.ts
@@ -175,12 +175,39 @@ export class PaymentMethodController extends GivingBaseController {
               });
             }
           } else if (gateway.provider?.toLowerCase() === "kingdomfunding" && Array.isArray(rawPaymentMethods)) {
-            // Only show KF payment methods that have a local record (user hasn't "deleted" them)
-            const localRecords = await this.repos.gatewayPaymentMethod.loadByCustomer(au.churchId, gateway.id, customer.id!);
+            // Soft-delete model: a payment method only appears if it has a local
+            // gatewayPaymentMethods record. Users can "delete" without revoking the
+            // card at the gateway (which would break any other system using it).
+            //
+            // Bootstrap path: if the local table is empty for this customer but the
+            // gateway has cards (e.g. first load of a church that already had Kingdom
+            // Funding cards, or after a local DB clear during dev/migration), auto-import
+            // them as a one-time seed so the soft-delete model has something to track.
+            let localRecords = await this.repos.gatewayPaymentMethod.loadByCustomer(au.churchId, gateway.id, customer.id!);
+            if (localRecords.length === 0 && rawPaymentMethods.length > 0) {
+              for (const pm of rawPaymentMethods) {
+                const pmId = String(pm.id);
+                const isBank = pm.type === "check";
+                const last4 = pm.last_4 || pm.last4 || "";
+                const cardType = pm.card_type || pm.type || (isBank ? "Bank" : "Card");
+                try {
+                  await this.repos.gatewayPaymentMethod.save({
+                    churchId: au.churchId,
+                    gatewayId: gateway.id,
+                    customerId: customer.id,
+                    externalId: pmId,
+                    methodType: isBank ? "bank" : "card",
+                    displayName: `${cardType} •••• ${last4}`.trim(),
+                    metadata: { status: "active", brand: cardType, last4 }
+                  });
+                } catch (e) { /* ignore individual import failures */ }
+              }
+              localRecords = await this.repos.gatewayPaymentMethod.loadByCustomer(au.churchId, gateway.id, customer.id!);
+            }
             const localExternalIds = new Set(localRecords.map((r: any) => String(r.externalId)));
             for (const pm of rawPaymentMethods) {
               const pmId = String(pm.id);
-              if (!localExternalIds.has(pmId)) continue; // Skip payment methods removed by user
+              if (!localExternalIds.has(pmId)) continue; // soft-deleted by user
               const cardType = pm.card_type || pm.type || "Card";
               const last4 = pm.last_4 || pm.last4 || "";
               normalizedMethods.push({
@@ -620,7 +647,6 @@ export class PaymentMethodController extends GivingBaseController {
       }
 
       const gateway = await GatewayService.getGatewayForChurch(au.churchId, { provider: resolvedProvider }, this.repos.gateway).catch(() => null);
-      console.log("[PM Delete] resolvedProvider:", resolvedProvider, "gateway found:", !!gateway, "pmId:", id, "customerId:", customerId);
 
       let permission = false;
       if (gateway) {
@@ -638,31 +664,24 @@ export class PaymentMethodController extends GivingBaseController {
           }
         }
       }
-      console.log("[PM Delete] permission:", permission);
       if (!permission) return this.json({}, 401);
 
       try {
-        console.log("[PM Delete] Calling detachPaymentMethod for", resolvedProvider, "pmId:", id);
-
-        let remoteDeleteOk = false;
         try {
           if (id.startsWith("ba_")) {
             await GatewayService.deleteBankAccount(gateway, customerId, id);
           } else {
             await GatewayService.detachPaymentMethod(gateway, id);
           }
-          remoteDeleteOk = true;
         } catch (detachErr: any) {
           const msg = detachErr?.message || "";
           if (resolvedProvider === "kingdomfunding" && msg.includes("active recurring")) {
             // Try to cancel linked subscriptions, then retry
-            console.log("[PM Delete] PM has active recurring schedules, attempting to cancel and retry...");
             try {
               const provider = GatewayFactory.getProvider(gateway.provider);
               const config = GatewayService.getGatewayConfig(gateway);
               const schedules = await (provider as any).getCustomerSubscriptions(config, customerId);
               const activeSchedules = (schedules || []).filter((s: any) => s.payment_method_id?.toString() === id && s.active !== false);
-              console.log("[PM Delete] Cancelling", activeSchedules.length, "active subscriptions");
               for (const schedule of activeSchedules) {
                 try {
                   await provider.cancelSubscription(config, schedule.id.toString());
@@ -672,7 +691,6 @@ export class PaymentMethodController extends GivingBaseController {
                 }
               }
               await GatewayService.detachPaymentMethod(gateway, id);
-              remoteDeleteOk = true;
             } catch (retryErr: any) {
               // Could not delete from Accept Blue — proceed to clean up locally only
               console.warn("[PM Delete] Could not delete PM from provider, cleaning up local records only:", retryErr?.message || retryErr);
@@ -688,7 +706,6 @@ export class PaymentMethodController extends GivingBaseController {
           await this.repos.gatewayPaymentMethod.deleteByExternalId(au.churchId, gateway.id, id);
         }
 
-        console.log("[PM Delete] Done. Remote delete:", remoteDeleteOk ? "success" : "skipped (local cleanup only)");
         return this.json({});
       } catch (e: any) {
         return this.json({

--- a/src/modules/giving/controllers/PaymentMethodController.ts
+++ b/src/modules/giving/controllers/PaymentMethodController.ts
@@ -2,6 +2,7 @@ import { controller, httpPost, httpGet, requestParam, httpDelete } from "inversi
 import express from "express";
 import { GivingBaseController } from "./GivingBaseController.js";
 import { GatewayService } from "../../../shared/helpers/GatewayService.js";
+import { GatewayFactory } from "../../../shared/helpers/gateways/GatewayFactory.js";
 import { Permissions } from "../../../shared/helpers/Permissions.js";
 import { GatewayPaymentMethod } from "../models/index.js";
 
@@ -107,112 +108,92 @@ export class PaymentMethodController extends GivingBaseController {
   @httpGet("/personid/:id")
   public async getPersonPaymentMethods(@requestParam("id") id: string, req: express.Request<{}, {}, null>, res: express.Response): Promise<any> {
     return this.actionWrapper(req, res, async (au) => {
-      // Default to Stripe for payment method operations (vault requires Stripe or PayPal)
-      const gateway = await GatewayService.getGatewayForChurch(au.churchId, { provider: "stripe" }, this.repos.gateway).catch(() => null);
-      const permission = gateway && (au.checkAccess(Permissions.donations.view) || id === au.personId);
-      if (!permission) return this.json({}, 401);
+      if (!au.checkAccess(Permissions.donations.view) && id !== au.personId) return this.json({}, 401);
 
-      // Check if provider supports vault/stored payment methods
-      const capabilities = GatewayService.getProviderCapabilities(gateway);
-      if (!capabilities?.supportsVault) {
-        return []; // Return empty array for providers without vault support
-      }
+      // Load ALL gateways for this church
+      const allGateways = (await this.repos.gateway.loadAll(au.churchId)) as any[];
+      if (!allGateways?.length) return [];
 
-      let customer = await this.repos.customer.loadByPersonAndProvider(au.churchId, id, gateway.provider);
-      if (!customer) {
-        customer = await this.repos.customer.loadByPersonId(au.churchId, id);
-      }
-
-      console.log("Customer lookup result:", customer);
-
-      if (!customer) return [];
-      const rawPaymentMethods = await GatewayService.getCustomerPaymentMethods(gateway, customer);
-
-      // Debug logging
-      //console.log("Raw payment methods from gateway:", JSON.stringify(rawPaymentMethods, null, 2));
-
-      // Normalize payment methods to consistent format
       const normalizedMethods: any[] = [];
 
-      if (gateway.provider?.toLowerCase() === "stripe" && Array.isArray(rawPaymentMethods)) {
-        for (const customerData of rawPaymentMethods) {
-          // Handle Stripe payment methods (cards)
-          if (customerData.cards?.data) {
-            for (const pm of customerData.cards.data) {
-              // Stripe PaymentMethod object structure
-              normalizedMethods.push({
-                id: pm.id,
-                type: "card",
-                provider: "stripe",
-                name: pm.card?.brand || "Card",
-                last4: pm.card?.last4,
-                customerId: pm.customer || customerData.customer?.id,
-                status: "active"
-              });
-            }
-          }
+      for (const gw of allGateways) {
+        const capabilities = GatewayService.getProviderCapabilities(gw);
+        if (!capabilities?.supportsVault) continue;
 
-          // Handle Stripe bank accounts (PaymentMethod API - us_bank_account)
-          if (customerData.banks?.data) {
-            for (const bank of customerData.banks.data) {
-              // Stripe PaymentMethod (us_bank_account) object structure
-              normalizedMethods.push({
-                id: bank.id,
-                type: "bank",
-                provider: "stripe",
-                name: bank.us_bank_account?.bank_name || "Bank Account",
-                last4: bank.us_bank_account?.last4,
-                customerId: bank.customer || customerData.customer?.id,
-                status: "active"
-              });
-            }
-          }
+        let customer = await this.repos.customer.loadByPersonAndProvider(au.churchId, id, gw.provider);
+        if (!customer) customer = await this.repos.customer.loadByPersonId(au.churchId, id);
+        if (!customer) continue;
 
-          // Handle legacy Stripe bank accounts (Sources API - deprecated)
-          if (customerData.legacyBanks?.data) {
-            for (const bank of customerData.legacyBanks.data) {
-              // Legacy Stripe Source (bank_account) object structure
+        try {
+          const gateway = await GatewayService.getGatewayForChurch(au.churchId, { gatewayId: gw.id }, this.repos.gateway);
+          const rawPaymentMethods = await GatewayService.getCustomerPaymentMethods(gateway, customer);
+
+          if (gateway.provider?.toLowerCase() === "stripe" && Array.isArray(rawPaymentMethods)) {
+            for (const customerData of rawPaymentMethods) {
+              if (customerData.cards?.data) {
+                for (const pm of customerData.cards.data) {
+                  normalizedMethods.push({
+                    id: pm.id, type: "card", provider: "stripe",
+                    name: pm.card?.brand || "Card", last4: pm.card?.last4,
+                    customerId: pm.customer || customerData.customer?.id,
+                    gatewayId: gateway.id, status: "active"
+                  });
+                }
+              }
+              if (customerData.banks?.data) {
+                for (const bank of customerData.banks.data) {
+                  normalizedMethods.push({
+                    id: bank.id, type: "bank", provider: "stripe",
+                    name: bank.us_bank_account?.bank_name || "Bank Account",
+                    last4: bank.us_bank_account?.last4,
+                    customerId: bank.customer || customerData.customer?.id,
+                    gatewayId: gateway.id, status: "active"
+                  });
+                }
+              }
+              if (customerData.legacyBanks?.data) {
+                for (const bank of customerData.legacyBanks.data) {
+                  normalizedMethods.push({
+                    id: bank.id, type: "bank", provider: "stripe",
+                    name: "Bank Account", last4: bank.last4,
+                    customerId: bank.customer || customerData.customer?.id,
+                    gatewayId: gateway.id, status: bank.status || "new", isLegacy: true
+                  });
+                }
+              }
+            }
+          } else if (gateway.provider?.toLowerCase() === "paypal" && Array.isArray(rawPaymentMethods)) {
+            const stored = await this.repos.gatewayPaymentMethod.loadByCustomer(au.churchId, gateway.id, customer.id!);
+            const lookup = new Map(stored.map((record) => [record.externalId, record]));
+            for (const method of rawPaymentMethods) {
+              const record = lookup.get(method?.id);
               normalizedMethods.push({
-                id: bank.id,
-                type: "bank",
-                provider: "stripe",
-                name: "Bank Account",
-                last4: bank.last4,
-                customerId: bank.customer || customerData.customer?.id,
-                status: bank.status || "new",
-                isLegacy: true  // Flag to identify legacy sources
+                id: method.id, type: "paypal", provider: "paypal",
+                name: record?.displayName || "PayPal", email: method.email,
+                customerId: record?.customerId || customer.id,
+                gatewayId: gateway.id
+              });
+            }
+          } else if (gateway.provider?.toLowerCase() === "kingdomfunding" && Array.isArray(rawPaymentMethods)) {
+            // Only show KF payment methods that have a local record (user hasn't "deleted" them)
+            const localRecords = await this.repos.gatewayPaymentMethod.loadByCustomer(au.churchId, gateway.id, customer.id!);
+            const localExternalIds = new Set(localRecords.map((r: any) => String(r.externalId)));
+            for (const pm of rawPaymentMethods) {
+              const pmId = String(pm.id);
+              if (!localExternalIds.has(pmId)) continue; // Skip payment methods removed by user
+              const cardType = pm.card_type || pm.type || "Card";
+              const last4 = pm.last_4 || pm.last4 || "";
+              normalizedMethods.push({
+                id: pmId, type: pm.type === "check" ? "bank" : "card",
+                provider: "kingdomfunding",
+                name: cardType, last4,
+                customerId: customer.id,
+                gatewayId: gateway.id, status: "active"
               });
             }
           }
-        }
-      } else if (gateway.provider?.toLowerCase() === "paypal" && Array.isArray(rawPaymentMethods)) {
-        const stored = await this.repos.gatewayPaymentMethod.loadByCustomer(au.churchId, gateway.id, customer.id!);
-        if (stored.length) {
-          const lookup = new Map(stored.map((record) => [record.externalId, record]));
-          for (const method of rawPaymentMethods) {
-            const record = lookup.get(method?.id);
-            const normalizedMethod = {
-              id: method.id,
-              type: "paypal",
-              provider: "paypal",
-              name: record?.displayName || "PayPal",
-              email: method.email,
-              customerId: record?.customerId || customer.id
-            };
-            normalizedMethods.push(record ? { ...normalizedMethod, localRecord: record } : normalizedMethod);
-          }
-        } else {
-          // No stored records, just normalize what we have
-          for (const method of rawPaymentMethods) {
-            normalizedMethods.push({
-              id: method.id,
-              type: "paypal",
-              provider: "paypal",
-              name: "PayPal",
-              email: method.email,
-              customerId: customer.id
-            });
-          }
+        } catch (e) {
+          console.warn(`Failed to load payment methods for gateway ${gw.id} (${gw.provider}):`, e);
         }
       }
 
@@ -243,7 +224,12 @@ export class PaymentMethodController extends GivingBaseController {
         return this.json({ error: "Invalid payment method ID format" }, 400);
       }
 
+      // For non-Stripe providers, look up the provider-specific customer instead of using the passed-in (Stripe) customer ID
       let customer = customerId;
+      if (gateway.provider?.toLowerCase() !== "stripe" && personId) {
+        const providerCustomer = await this.repos.customer.loadByPersonAndProvider(cId, personId, gateway.provider) as any;
+        customer = providerCustomer?.id || undefined;
+      }
       if (!customer) {
         try {
           customer = await GatewayService.createCustomer(gateway, email, name);
@@ -256,27 +242,90 @@ export class PaymentMethodController extends GivingBaseController {
       }
 
       try {
-        const pm = await GatewayService.attachPaymentMethod(gateway, id, { customer });
-        if (gateway.provider === "paypal" && customer) {
-          const tokenId = pm?.id || id;
+        const buildAttachOptions = (custId: string) => {
+          const opts: any = { customer: custId, customerId: custId };
+          if (gateway.provider?.toLowerCase() === "kingdomfunding") {
+            // Detect ACH vs card based on which fields the frontend sent
+            if (req.body.routing_number && req.body.account_number) {
+              opts.routing_number = req.body.routing_number;
+              opts.account_number = req.body.account_number;
+              opts.account_type = req.body.account_type || "checking";
+              opts.name = req.body.name;
+            } else {
+              opts.source = id;
+              if (req.body.expiry_month) opts.expiry_month = req.body.expiry_month;
+              if (req.body.expiry_year) opts.expiry_year = req.body.expiry_year;
+              if (req.body.cardBrand) opts.cardBrand = req.body.cardBrand;
+              if (req.body.cardLast4) opts.cardLast4 = req.body.cardLast4;
+            }
+          }
+          return opts;
+        };
+
+        let pm: any;
+        try {
+          pm = await GatewayService.attachPaymentMethod(gateway, id, buildAttachOptions(customer));
+        } catch (attachErr: any) {
+          // If customer doesn't exist on the provider (404/Not Found), recreate and retry
+          const status = attachErr.response?.status || attachErr.statusCode;
+          if (status === 404 && gateway.provider?.toLowerCase() !== "stripe") {
+            console.log(`Customer ${customer} not found on ${gateway.provider}, recreating...`);
+            const newCustomer = await GatewayService.createCustomer(gateway, email, name);
+            if (newCustomer) {
+              await this.repos.customer.save({ id: newCustomer, churchId: cId, personId, provider: gateway.provider });
+              customer = newCustomer;
+              pm = await GatewayService.attachPaymentMethod(gateway, id, buildAttachOptions(customer));
+            } else {
+              throw attachErr;
+            }
+          } else {
+            throw attachErr;
+          }
+        }
+
+        // Save to gatewayPaymentMethods for non-Stripe providers
+        if ((gateway.provider?.toLowerCase() === "paypal" || gateway.provider?.toLowerCase() === "kingdomfunding") && customer) {
+          const tokenId = pm?.id ? String(pm.id) : id;
           if (tokenId) {
-            const paymentSource = pm?.payment_source || {};
-            const card = paymentSource.card as { last4?: string; brand?: string } | undefined;
-            const paypalSource = paymentSource.paypal as { email_address?: string } | undefined;
+            let methodType = "token";
+            let displayName = "";
 
-            const methodType = card
-              ? "card"
-              : paypalSource
-                ? "paypal"
-                : typeof pm?.type === "string"
-                  ? pm.type
-                  : "token";
+            if (gateway.provider?.toLowerCase() === "paypal") {
+              const paymentSource = pm?.payment_source || {};
+              const card = paymentSource.card as { last4?: string; brand?: string } | undefined;
+              const paypalSource = paymentSource.paypal as { email_address?: string } | undefined;
+              methodType = card ? "card" : paypalSource ? "paypal" : typeof pm?.type === "string" ? pm.type : "token";
+              displayName = card
+                ? `${(card.brand || "Card").toUpperCase()} •••• ${card.last4 ?? ""}`.trim()
+                : paypalSource?.email_address || `PayPal token ${tokenId.substring(0, 6)}...`;
+            } else {
+              // KingdomFunding — detect card vs bank/check
+              const isBank = pm?.type === "check"
+                || pm?.account_type
+                || !!pm?.routing_number
+                || !!req.body.routing_number;
 
-            const displayName = card
-              ? `${(card.brand || "Card").toUpperCase()} •••• ${card.last4 ?? ""}`.trim()
-              : paypalSource?.email_address || `PayPal token ${tokenId.substring(0, 6)}...`;
+              if (isBank) {
+                methodType = "bank";
+                const acctType = pm?.account_type || req.body.account_type || "checking";
+                const last4 = pm?.last4
+                  || (pm?.account_number ? String(pm.account_number).slice(-4) : "")
+                  || (req.body.account_number ? String(req.body.account_number).slice(-4) : "");
+                const acctLabel = acctType.charAt(0).toUpperCase() + acctType.slice(1);
+                displayName = `Bank ${acctLabel} •••• ${last4}`.trim();
+              } else {
+                methodType = "card";
+                const cardType = pm?.card_type || req.body.cardBrand || "Card";
+                const last4 = pm?.last_4 || req.body.cardLast4 || "";
+                displayName = `${cardType} •••• ${last4}`.trim();
+              }
+            }
 
             const existing = await this.repos.gatewayPaymentMethod.loadByExternalId(cId, gateway.id, tokenId);
+            const isBankRecord = methodType === "bank";
+            const recordLast4 = isBankRecord
+              ? (pm?.last4 || (pm?.account_number ? String(pm.account_number).slice(-4) : "") || (req.body.account_number ? String(req.body.account_number).slice(-4) : ""))
+              : (pm?.last_4 || req.body.cardLast4 || "");
             const record: GatewayPaymentMethod = {
               id: existing?.id,
               churchId: cId,
@@ -287,8 +336,10 @@ export class PaymentMethodController extends GivingBaseController {
               displayName,
               metadata: {
                 status: pm?.status,
-                brand: card?.brand,
-                last4: card?.last4
+                brand: isBankRecord
+                  ? (pm?.account_type || req.body.account_type || "Bank")
+                  : (pm?.card_type || req.body.cardBrand),
+                last4: recordLast4
               }
             };
             await this.repos.gatewayPaymentMethod.save(record);
@@ -549,32 +600,101 @@ export class PaymentMethodController extends GivingBaseController {
   @httpDelete("/:id/:customerid")
   public async deletePaymentMethod(@requestParam("id") id: string, @requestParam("customerid") customerId: string, req: express.Request<{}, {}, null>, res: express.Response): Promise<any> {
     return this.actionWrapper(req, res, async (au) => {
-      // Determine provider from payment method ID prefix (pm_ and ba_ are Stripe)
+      // Determine provider: pm_ and ba_ are Stripe, otherwise check query param or look up in gatewayPaymentMethods
+      const providerParam = (req.query as any).provider?.toLowerCase();
       const isStripe = id.startsWith("pm_") || id.startsWith("ba_");
-      const gateway = await GatewayService.getGatewayForChurch(au.churchId, { provider: isStripe ? "stripe" : "paypal" }, this.repos.gateway).catch(() => null);
-      const permission =
-        gateway &&
-        (au.checkAccess(Permissions.donations.edit) || (await this.repos.customer.convertToModel(au.churchId, await this.repos.customer.load(au.churchId, customerId)).personId) === au.personId);
+      let resolvedProvider = providerParam || (isStripe ? "stripe" : null);
+
+      // If provider not determined, look up in gatewayPaymentMethods table
+      if (!resolvedProvider) {
+        const localRecord = await this.repos.gatewayPaymentMethod.loadByExternalIdAcrossGateways(au.churchId, id);
+        if (localRecord) {
+          const gw = (await this.repos.gateway.loadAll(au.churchId) as any[]).find(g => g.id === localRecord.gatewayId);
+          resolvedProvider = gw?.provider?.toLowerCase() || "paypal";
+        } else if (/^\d+$/.test(id)) {
+          // Numeric IDs are Accept Blue / KingdomFunding payment method IDs
+          resolvedProvider = "kingdomfunding";
+        } else {
+          resolvedProvider = "paypal"; // fallback for backward compat
+        }
+      }
+
+      const gateway = await GatewayService.getGatewayForChurch(au.churchId, { provider: resolvedProvider }, this.repos.gateway).catch(() => null);
+      console.log("[PM Delete] resolvedProvider:", resolvedProvider, "gateway found:", !!gateway, "pmId:", id, "customerId:", customerId);
+
+      let permission = false;
+      if (gateway) {
+        if (au.checkAccess(Permissions.donations.edit)) {
+          permission = true;
+        } else {
+          try {
+            const customerData = await this.repos.customer.load(au.churchId, customerId);
+            if (customerData) {
+              const customer = this.repos.customer.convertToModel(au.churchId, customerData as any);
+              permission = customer.personId === au.personId;
+            }
+          } catch (permErr) {
+            console.error("[PM Delete] Permission check error:", permErr);
+          }
+        }
+      }
+      console.log("[PM Delete] permission:", permission);
       if (!permission) return this.json({}, 401);
-      else {
+
+      try {
+        console.log("[PM Delete] Calling detachPaymentMethod for", resolvedProvider, "pmId:", id);
+
+        let remoteDeleteOk = false;
         try {
           if (id.startsWith("ba_")) {
             await GatewayService.deleteBankAccount(gateway, customerId, id);
           } else {
             await GatewayService.detachPaymentMethod(gateway, id);
           }
-
-          if (gateway.provider === "paypal") {
-            await this.repos.gatewayPaymentMethod.deleteByExternalId(au.churchId, gateway.id, id);
+          remoteDeleteOk = true;
+        } catch (detachErr: any) {
+          const msg = detachErr?.message || "";
+          if (resolvedProvider === "kingdomfunding" && msg.includes("active recurring")) {
+            // Try to cancel linked subscriptions, then retry
+            console.log("[PM Delete] PM has active recurring schedules, attempting to cancel and retry...");
+            try {
+              const provider = GatewayFactory.getProvider(gateway.provider);
+              const config = GatewayService.getGatewayConfig(gateway);
+              const schedules = await (provider as any).getCustomerSubscriptions(config, customerId);
+              const activeSchedules = (schedules || []).filter((s: any) => s.payment_method_id?.toString() === id && s.active !== false);
+              console.log("[PM Delete] Cancelling", activeSchedules.length, "active subscriptions");
+              for (const schedule of activeSchedules) {
+                try {
+                  await provider.cancelSubscription(config, schedule.id.toString());
+                  await this.repos.subscription.delete(au.churchId, schedule.id.toString()).catch(() => {});
+                } catch (cancelErr: any) {
+                  console.error("[PM Delete] Failed to cancel schedule", schedule.id, cancelErr.message);
+                }
+              }
+              await GatewayService.detachPaymentMethod(gateway, id);
+              remoteDeleteOk = true;
+            } catch (retryErr: any) {
+              // Could not delete from Accept Blue — proceed to clean up locally only
+              console.warn("[PM Delete] Could not delete PM from provider, cleaning up local records only:", retryErr?.message || retryErr);
+            }
+          } else {
+            throw detachErr;
           }
-
-          return this.json({});
-        } catch (e: any) {
-          return this.json({
-            error: e?.message || "Failed to delete payment method",
-            code: e?.code || "unknown_error"
-          }, e?.statusCode || 500);
         }
+
+        // Always clean up local records for non-Stripe providers
+        const prov = gateway.provider?.toLowerCase();
+        if (prov === "paypal" || prov === "kingdomfunding") {
+          await this.repos.gatewayPaymentMethod.deleteByExternalId(au.churchId, gateway.id, id);
+        }
+
+        console.log("[PM Delete] Done. Remote delete:", remoteDeleteOk ? "success" : "skipped (local cleanup only)");
+        return this.json({});
+      } catch (e: any) {
+        return this.json({
+          error: e?.message || "Failed to delete payment method",
+          code: e?.code || "unknown_error"
+        }, e?.statusCode || 500);
       }
     });
   }

--- a/src/modules/giving/controllers/SubscriptionController.ts
+++ b/src/modules/giving/controllers/SubscriptionController.ts
@@ -27,21 +27,30 @@ export class SubscriptionController extends GivingBaseController {
   public async save(req: express.Request<{}, {}, any[]>, res: express.Response): Promise<any> {
     return this.actionWrapper(req, res, async (au) => {
       const promises: Promise<any>[] = [];
-      // Subscriptions are Stripe-only currently
-      const gateway = await GatewayService.getGatewayForChurch(au.churchId, { provider: "stripe" }, this.repos.gateway).catch(() => null);
-
-      if (!gateway) return this.json({ error: "No gateway configured" }, 400);
-
-      const capabilities = GatewayService.getProviderCapabilities(gateway);
-      if (!capabilities?.supportsSubscriptions) {
-        return this.json({ error: `${gateway.provider} does not support subscription management` }, 400);
-      }
 
       for (const subscription of req.body) {
-        const existingSub = await this.repos.subscription.load(au.churchId, subscription.id);
-        const permission = au.checkAccess(Permissions.donations.edit) || (existingSub as any)?.personId === au.personId;
+        const existingSub = await this.repos.subscription.load(au.churchId, subscription.id) as any;
+        const permission = au.checkAccess(Permissions.donations.edit) || existingSub?.personId === au.personId;
+        if (!permission) continue;
 
-        if (permission) {
+        // Resolve gateway via provider param or by looking up the customer's provider
+        const provider = subscription.provider;
+        let gateway = provider
+          ? await GatewayService.getGatewayForChurch(au.churchId, { provider }, this.repos.gateway).catch(() => null)
+          : null;
+
+        if (!gateway && existingSub?.customerId) {
+          // Look up customer to determine which provider this subscription belongs to
+          const customer = await this.repos.customer.load(au.churchId, existingSub.customerId) as any;
+          const custProvider = customer?.provider || "stripe";
+          gateway = await GatewayService.getGatewayForChurch(au.churchId, { provider: custProvider }, this.repos.gateway).catch(() => null);
+        }
+
+        if (!gateway) {
+          gateway = await GatewayService.getGatewayForChurch(au.churchId, { provider: "stripe" }, this.repos.gateway).catch(() => null);
+        }
+
+        if (gateway) {
           promises.push(GatewayService.updateSubscription(gateway, subscription));
         }
       }
@@ -54,29 +63,33 @@ export class SubscriptionController extends GivingBaseController {
   @httpDelete("/:id")
   public async delete(@requestParam("id") id: string, req: express.Request<{}, {}, { provider?: string; reason?: string }>, res: express.Response): Promise<any> {
     return this.actionWrapper(req, res, async (au) => {
-      const subscription = await this.repos.subscription.load(au.churchId, id);
-      const permission = au.checkAccess(Permissions.donations.edit) || (subscription as any)?.personId === au.personId;
+      const subscription = await this.repos.subscription.load(au.churchId, id) as any;
+      const permission = au.checkAccess(Permissions.donations.edit) || subscription?.personId === au.personId;
       if (!permission) return this.json(null, 401);
 
-      // Subscriptions are Stripe-only currently
-      const gateway = await GatewayService.getGatewayForChurch(au.churchId, { provider: "stripe" }, this.repos.gateway).catch(() => null);
-      if (!gateway) return this.json({ error: "No gateway configured" }, 400);
+      // Resolve gateway via provider query/body param or by looking up the customer's provider
+      const provider = req.query?.provider?.toString() || req.body?.provider;
+      let gateway = provider
+        ? await GatewayService.getGatewayForChurch(au.churchId, { provider }, this.repos.gateway).catch(() => null)
+        : null;
 
-      const capabilities = GatewayService.getProviderCapabilities(gateway);
-      if (!capabilities?.supportsSubscriptions) {
-        return this.json({ error: `${gateway.provider} does not support subscription management` }, 400);
+      if (!gateway && subscription?.customerId) {
+        const customer = await this.repos.customer.load(au.churchId, subscription.customerId) as any;
+        const custProvider = customer?.provider || "stripe";
+        gateway = await GatewayService.getGatewayForChurch(au.churchId, { provider: custProvider }, this.repos.gateway).catch(() => null);
       }
 
+      if (!gateway) {
+        gateway = await GatewayService.getGatewayForChurch(au.churchId, { provider: "stripe" }, this.repos.gateway).catch(() => null);
+      }
+
+      if (!gateway) return this.json({ error: "No gateway configured" }, 400);
+
       try {
-        const promises: Promise<any>[] = [];
-
         // Cancel subscription with the gateway
-        promises.push(GatewayService.cancelSubscription(gateway, id, req.body?.reason));
-
+        await GatewayService.cancelSubscription(gateway, id, req.body?.reason);
         // Delete from database
-        promises.push(this.repos.subscription.delete(au.churchId, id));
-
-        await Promise.all(promises);
+        await this.repos.subscription.delete(au.churchId, id);
         return this.json({ success: true });
       } catch (error) {
         console.error("Subscription cancellation failed:", error);

--- a/src/modules/giving/controllers/SubscriptionController.ts
+++ b/src/modules/giving/controllers/SubscriptionController.ts
@@ -64,14 +64,30 @@ export class SubscriptionController extends GivingBaseController {
   public async delete(@requestParam("id") id: string, req: express.Request<{}, {}, { provider?: string; reason?: string }>, res: express.Response): Promise<any> {
     return this.actionWrapper(req, res, async (au) => {
       const subscription = await this.repos.subscription.load(au.churchId, id) as any;
-      const permission = au.checkAccess(Permissions.donations.edit) || subscription?.personId === au.personId;
-      if (!permission) return this.json(null, 401);
+      let permission = au.checkAccess(Permissions.donations.edit) || subscription?.personId === au.personId;
 
       // Resolve gateway via provider query/body param or by looking up the customer's provider
       const provider = req.query?.provider?.toString() || req.body?.provider;
       let gateway = provider
         ? await GatewayService.getGatewayForChurch(au.churchId, { provider }, this.repos.gateway).catch(() => null)
         : null;
+
+      // KingdomFunding subscriptions are not persisted in the local `subscription`
+      // table, so the personId-on-subscription check above can never grant access.
+      // Fall back to verifying that the schedule's customer_id matches the
+      // requester's KF customer record for this church.
+      if (!permission && !subscription && provider?.toLowerCase() === "kingdomfunding" && gateway) {
+        const schedule = await GatewayService.getSubscription(gateway, id).catch(() => null);
+        const remoteCustomerId = schedule?.customer_id ? String(schedule.customer_id) : null;
+        if (remoteCustomerId) {
+          const ownerCustomer = await this.repos.customer.loadByPersonAndProvider(au.churchId, au.personId, provider).catch(() => null) as any;
+          if (ownerCustomer && String(ownerCustomer.id) === remoteCustomerId) {
+            permission = true;
+          }
+        }
+      }
+
+      if (!permission) return this.json(null, 401);
 
       if (!gateway && subscription?.customerId) {
         const customer = await this.repos.customer.load(au.churchId, subscription.customerId) as any;

--- a/src/modules/giving/repositories/GatewayPaymentMethodRepo.ts
+++ b/src/modules/giving/repositories/GatewayPaymentMethodRepo.ts
@@ -58,6 +58,15 @@ export class GatewayPaymentMethodRepo {
     return row ? this.rowToModel(row) : null;
   }
 
+  public async loadByExternalIdAcrossGateways(churchId: string, externalId: string): Promise<GatewayPaymentMethod | null> {
+    const row = (await getDb().selectFrom("gatewayPaymentMethods").selectAll()
+      .where("churchId", "=", churchId)
+      .where("externalId", "=", externalId)
+      .limit(1)
+      .executeTakeFirst()) ?? null;
+    return row ? this.rowToModel(row) : null;
+  }
+
   public async deleteByExternalId(churchId: string, gatewayId: string, externalId: string): Promise<void> {
     await getDb().deleteFrom("gatewayPaymentMethods")
       .where("churchId", "=", churchId)

--- a/src/shared/helpers/GatewayService.ts
+++ b/src/shared/helpers/GatewayService.ts
@@ -167,6 +167,15 @@ export class GatewayService {
     return [];
   }
 
+  static async getSubscription(gateway: any, subscriptionId: string): Promise<any> {
+    const provider = this.getProviderFromGateway(gateway);
+    if (typeof provider.getSubscription === "function") {
+      const config = this.getGatewayConfig(gateway);
+      return await provider.getSubscription(config, subscriptionId);
+    }
+    return null;
+  }
+
   static async getCustomerPaymentMethods(gateway: any, customer: any): Promise<any> {
     const provider = this.getProviderFromGateway(gateway);
     if (provider.getCustomerPaymentMethods) {

--- a/src/shared/helpers/GatewayService.ts
+++ b/src/shared/helpers/GatewayService.ts
@@ -498,6 +498,27 @@ export class GatewayService {
         minTransactionAmount: 100, // $1.00
         maxTransactionAmount: 10000000, // $100,000.00
         notes: ["Webhooks limited; polling recommended", "ACH available via tokenised transactions"]
+      },
+      kingdomfunding: {
+        supportsOneTimePayments: true,
+        supportsSubscriptions: true,
+        supportsVault: true,
+        supportsACH: true,
+        supportsRefunds: true,
+        supportsPartialRefunds: true,
+        supportsWebhooks: true,
+        supportsOrders: false,
+        supportedPaymentMethods: ["card", "ach"],
+        supportedCurrencies: ["usd"],
+        requiresPlansForSubscriptions: false,
+        requiresCustomerForSubscription: true,
+        supportsInstantCapture: true,
+        supportsManualCapture: false,
+        supportsSCA: false,
+        maxRefundWindow: 180,
+        minTransactionAmount: 1,
+        maxTransactionAmount: 2000000000,
+        notes: ["Powered by KingdomFunding", "Reusable saved payment methods", "Single-step recurring schedules"]
       }
     };
 

--- a/src/shared/helpers/gateways/GatewayFactory.ts
+++ b/src/shared/helpers/gateways/GatewayFactory.ts
@@ -3,6 +3,7 @@ import { StripeGatewayProvider } from "./StripeGatewayProvider.js";
 import { PayPalGatewayProvider } from "./PayPalGatewayProvider.js";
 import { SquareGatewayProvider } from "./SquareGatewayProvider.js";
 import { EPayMintsGatewayProvider } from "./EPayMintsGatewayProvider.js";
+import { KingdomFundingGatewayProvider } from "./KingdomFundingGatewayProvider.js";
 
 export interface GatewayFeatureFlags {
   enableSquare?: boolean;
@@ -19,6 +20,7 @@ export class GatewayFactory {
     // Always register production-ready providers
     this.providers.set("stripe", new StripeGatewayProvider());
     this.providers.set("paypal", new PayPalGatewayProvider());
+    this.providers.set("kingdomfunding", new KingdomFundingGatewayProvider());
 
     // Load feature flags from environment or config
     this.loadFeatureFlags();

--- a/src/shared/helpers/gateways/GatewaySettings.ts
+++ b/src/shared/helpers/gateways/GatewaySettings.ts
@@ -59,12 +59,21 @@ export namespace ePayMintsSettings {
   }
 }
 
+// KingdomFunding-specific settings
+export namespace KingdomFundingSettings {
+  export interface Settings extends BaseGatewaySettings {
+    merchantId?: string;
+    webhookId?: string;
+  }
+}
+
 // Union type for all gateway settings
 export type GatewaySettings =
   | { provider: "stripe"; settings: StripeSettings.Settings }
   | { provider: "paypal"; settings: PayPalSettings.Settings }
   | { provider: "square"; settings: SquareSettings.Settings }
-  | { provider: "epaymints"; settings: ePayMintsSettings.Settings };
+  | { provider: "epaymints"; settings: ePayMintsSettings.Settings }
+  | { provider: "kingdomfunding"; settings: KingdomFundingSettings.Settings };
 
 // Type guard functions
 export function isStripeSettings(settings: any): settings is StripeSettings.Settings {
@@ -83,6 +92,10 @@ export function isEPayMintsSettings(settings: any): settings is ePayMintsSetting
   return settings && typeof settings === "object";
 }
 
+export function isKingdomFundingSettings(settings: any): settings is KingdomFundingSettings.Settings {
+  return settings && typeof settings === "object";
+}
+
 // Helper to validate and cast settings based on provider
 export function validateGatewaySettings(provider: string, settings: Record<string, unknown> | null): BaseGatewaySettings | null {
   if (!settings) return null;
@@ -92,6 +105,7 @@ export function validateGatewaySettings(provider: string, settings: Record<strin
     case "paypal": return isPayPalSettings(settings) ? settings : null;
     case "square": return isSquareSettings(settings) ? settings : null;
     case "epaymints": return isEPayMintsSettings(settings) ? settings : null;
+    case "kingdomfunding": return isKingdomFundingSettings(settings) ? settings : null;
     default: return null;
   }
 }

--- a/src/shared/helpers/gateways/IGatewayProvider.ts
+++ b/src/shared/helpers/gateways/IGatewayProvider.ts
@@ -55,6 +55,7 @@ export interface IGatewayProvider {
   // Customer management
   createCustomer?(config: GatewayConfig, email: string, name: string): Promise<string>;
   getCustomerSubscriptions?(config: GatewayConfig, customerId: string): Promise<any>;
+  getSubscription?(config: GatewayConfig, subscriptionId: string): Promise<any>;
   getCustomerPaymentMethods?(config: GatewayConfig, customer: any): Promise<any>;
 
   // Payment method management

--- a/src/shared/helpers/gateways/KingdomFundingGatewayProvider.ts
+++ b/src/shared/helpers/gateways/KingdomFundingGatewayProvider.ts
@@ -69,10 +69,8 @@ export class KingdomFundingGatewayProvider extends AbstractExperimentalGatewayPr
    * The API docs show webhook CRUD but we'll handle setup in the admin UI.
    * This method is a no-op placeholder; ensureWebhookExists() is the real entry point.
    */
-  async createWebhookEndpoint(config: GatewayConfig, webhookUrl: string): Promise<{ id: string; secret?: string }> {
-    // KingdomFunding webhook creation is done via the Control Panel
-    // Return empty — the admin should set this up manually or via ensureWebhookExists
-    console.log("KingdomFunding: createWebhookEndpoint called (webhooks configured via Control Panel)", { webhookUrl });
+  async createWebhookEndpoint(_config: GatewayConfig, _webhookUrl: string): Promise<{ id: string; secret?: string }> {
+    // KingdomFunding webhook creation is done via the Control Panel, not via API.
     return { id: "", secret: "" };
   }
 
@@ -518,7 +516,6 @@ export class KingdomFundingGatewayProvider extends AbstractExperimentalGatewayPr
           // If the payment method already exists for this customer, reuse it
           const existingPm = pmErr.response?.data?.error_details?.payment_method;
           if (existingPm?.id) {
-            console.log("KingdomFunding: Payment method already exists, reusing", { pmId: existingPm.id });
             paymentMethodId = existingPm.id;
           } else {
             console.error("KingdomFunding: Failed to create payment method", pmErr.response?.data || pmErr.message);
@@ -650,16 +647,12 @@ export class KingdomFundingGatewayProvider extends AbstractExperimentalGatewayPr
   async cancelSubscription(config: GatewayConfig, subscriptionId: string, _reason?: string): Promise<void> {
     try {
       const baseUrl = this.getBaseUrl(config);
-      console.log("KingdomFunding cancelSubscription: deactivating schedule", { subscriptionId, url: `${baseUrl}/recurring-schedules/${subscriptionId}` });
-
       // Deactivate by setting active: false
-      const response = await Axios.patch(
+      await Axios.patch(
         `${baseUrl}/recurring-schedules/${subscriptionId}`,
         { active: false },
         this.axiosConfig(config)
       );
-
-      console.log("KingdomFunding: Recurring schedule deactivated", { subscriptionId, responseData: response.data });
     } catch (error: any) {
       console.error("KingdomFunding cancelSubscription error:", {
         subscriptionId,
@@ -788,14 +781,40 @@ export class KingdomFundingGatewayProvider extends AbstractExperimentalGatewayPr
     }
   }
 
-  async getCustomerSubscriptions(config: GatewayConfig, customerId: string): Promise<any> {
+  async getSubscription(config: GatewayConfig, subscriptionId: string): Promise<any> {
     try {
       const baseUrl = this.getBaseUrl(config);
       const response = await Axios.get(
-        `${baseUrl}/customers/${customerId}/recurring-schedules`,
-        { ...this.axiosConfig(config), timeout: 15000 }
+        `${baseUrl}/recurring-schedules/${subscriptionId}`,
+        this.axiosConfig(config)
       );
-      return response.data || [];
+      return response.data || null;
+    } catch (error: any) {
+      console.error("KingdomFunding getSubscription error:", error.response?.data || error.message);
+      return null;
+    }
+  }
+
+  async getCustomerSubscriptions(config: GatewayConfig, customerId: string): Promise<any> {
+    try {
+      const baseUrl = this.getBaseUrl(config);
+      // Accept Blue paginates (default ~10/page) and may ignore per_page. Walk pages
+      // until we get an empty batch OR a page returns no new IDs (param ignored case).
+      const all: any[] = [];
+      const seen = new Set<string>();
+      for (let page = 1; page <= 50; page++) {
+        const response = await Axios.get(
+          `${baseUrl}/customers/${customerId}/recurring-schedules`,
+          { ...this.axiosConfig(config), timeout: 15000, params: { page, per_page: 100 } }
+        );
+        const batch: any[] = Array.isArray(response.data) ? response.data : (response.data?.data || []);
+        if (batch.length === 0) break;
+        const fresh = batch.filter((s: any) => !seen.has(String(s.id)));
+        if (fresh.length === 0) break;
+        fresh.forEach((s: any) => seen.add(String(s.id)));
+        all.push(...fresh);
+      }
+      return all;
     } catch (error: any) {
       console.error("KingdomFunding getCustomerSubscriptions error:", error.response?.data || error.message);
       return [];
@@ -835,14 +854,21 @@ export class KingdomFundingGatewayProvider extends AbstractExperimentalGatewayPr
 
       const payload: any = {};
 
+      // Accept Blue requires expiry_month / expiry_year as integers (not strings).
+      // Frontend tokenization returns them as strings — coerce here defensively.
+      const expMonth = options.expiry_month != null && options.expiry_month !== ""
+        ? Number(options.expiry_month) : undefined;
+      const expYear = options.expiry_year != null && options.expiry_year !== ""
+        ? Number(options.expiry_year) : undefined;
+
       const pmIdStr = paymentMethodId ? String(paymentMethodId) : "";
       if (options.source || pmIdStr.startsWith("nonce-") || pmIdStr.startsWith("ref-")) {
         // Save from a nonce token or transaction reference
         payload.source = options.source || pmIdStr;
         // Only auto-prefix with nonce- if it's not already prefixed
         if (!payload.source.startsWith("nonce-") && !payload.source.startsWith("ref-")) payload.source = `nonce-${payload.source}`;
-        if (options.expiry_month) payload.expiry_month = options.expiry_month;
-        if (options.expiry_year) payload.expiry_year = options.expiry_year;
+        if (expMonth != null && !Number.isNaN(expMonth)) payload.expiry_month = expMonth;
+        if (expYear != null && !Number.isNaN(expYear)) payload.expiry_year = expYear;
       } else if (options.routing_number) {
         // Save a check/ACH payment method
         payload.routing_number = options.routing_number;
@@ -853,19 +879,30 @@ export class KingdomFundingGatewayProvider extends AbstractExperimentalGatewayPr
       } else {
         // Save card data
         payload.card = options.card;
-        payload.expiry_month = options.expiry_month;
-        payload.expiry_year = options.expiry_year;
+        if (expMonth != null && !Number.isNaN(expMonth)) payload.expiry_month = expMonth;
+        if (expYear != null && !Number.isNaN(expYear)) payload.expiry_year = expYear;
         payload.name = options.name || "";
         if (options.avs_zip) payload.avs_zip = options.avs_zip;
       }
 
-      const response = await Axios.post(
-        `${baseUrl}/customers/${customerId}/payment-methods`,
-        payload,
-        this.axiosConfig(config)
-      );
-
-      return response.data;
+      try {
+        const response = await Axios.post(
+          `${baseUrl}/customers/${customerId}/payment-methods`,
+          payload,
+          this.axiosConfig(config)
+        );
+        return response.data;
+      } catch (err: any) {
+        // Accept Blue rejects duplicate card adds with an Invalid state error and
+        // returns the EXISTING payment_method in error_details. Treat that as success
+        // and reuse the existing payment-method ID.
+        const errDetails = err.response?.data?.error_details;
+        const existing = errDetails?.payment_method;
+        if (existing?.id) {
+          return existing;
+        }
+        throw err;
+      }
     } catch (error: any) {
       console.error("KingdomFunding attachPaymentMethod error:", JSON.stringify(error.response?.data) || error.message);
       throw new Error(error.response?.data?.error_message || error.message || "Failed to save payment method");
@@ -879,7 +916,6 @@ export class KingdomFundingGatewayProvider extends AbstractExperimentalGatewayPr
   async detachPaymentMethod(config: GatewayConfig, paymentMethodId: string, customerId?: string): Promise<any> {
     try {
       const baseUrl = this.getBaseUrl(config);
-      console.log("KingdomFunding detachPaymentMethod:", { paymentMethodId, customerId });
       const response = await Axios.delete(
         `${baseUrl}/payment-methods/${paymentMethodId}`,
         this.axiosConfig(config)

--- a/src/shared/helpers/gateways/KingdomFundingGatewayProvider.ts
+++ b/src/shared/helpers/gateways/KingdomFundingGatewayProvider.ts
@@ -7,25 +7,29 @@ import { Environment } from "../Environment.js";
 import { Donation, DonationBatch, EventLog, FundDonation } from "../../../modules/giving/models/index.js";
 
 /**
- * KingdomFunding payment gateway provider.
+ * KingdomFunding payment gateway provider — backed by NMI (Network Merchants Inc.).
+ *
+ * The "Kingdom Funding" name/branding is retained throughout the product; only the
+ * underlying gateway is NMI. (Previously this provider talked to Accept Blue; it was
+ * migrated to NMI because Accept Blue cannot tokenize ACH and NMI can — Collect.js
+ * tokenizes both card and ACH into a single-use `payment_token`.)
  *
  * Supports:
- * - One-time card charges (via hosted tokenization nonce)
- * - One-time ACH/check charges
- * - Recurring schedules (single-step, not plan+subscription)
- * - Customers with reusable saved payment methods
- * - Refunds (full + partial)
+ * - One-time card charges (via Collect.js payment_token)
+ * - One-time ACH/eCheck charges (via Collect.js payment_token OR raw routing/account)
+ * - Recurring subscriptions (vault the method, then add_subscription)
+ * - Customer Vault for reusable saved payment methods
+ * - Refunds (full + partial) and voids
  * - Webhooks with HMAC-SHA256 signature verification
  *
- * DB column mapping:
- *   gateways.publicKey    = Tokenization Key (pk_...)
- *   gateways.privateKey   = API Source Key (encrypted)
- *   gateways.webhookKey   = Webhook signature secret (encrypted)
- *   gateways.settings     = { webhookId?, merchantId? }
+ * DB column mapping (unchanged from before — only the meaning of each value changes):
+ *   gateways.publicKey    = NMI Collect.js public tokenization key (browser-side)
+ *   gateways.privateKey   = NMI Security Key (server-side secret, encrypted at rest)
+ *   gateways.webhookKey   = NMI webhook signing key (per-endpoint, encrypted at rest)
+ *   gateways.settings     = { merchantId?, webhookId? }
  *
- * Auth: HTTP Basic — Authorization: Basic base64(sourceKey:pin)
- * PIN is optional for sandbox, required for production CC refunds.
- * We store the sourceKey in privateKey. PIN (if any) is in settings.pin.
+ * NMI Payment API: POST application/x-www-form-urlencoded to transact.php.
+ * Responses are url-encoded key=value strings; response=1 Approved, 2 Declined, 3 Error.
  */
 export class KingdomFundingGatewayProvider extends AbstractExperimentalGatewayProvider {
   readonly name = "kingdomfunding";
@@ -36,135 +40,193 @@ export class KingdomFundingGatewayProvider extends AbstractExperimentalGatewayPr
 
   // ─── Helpers ──────────────────────────────────────────────
 
-  private getBaseUrl(config: GatewayConfig): string {
-    const key = config.privateKey || "";
-    // Sandbox uses develop subdomain; production uses main API domain
-    const isDev = config.environment === "sandbox"
-      || (config.settings as any)?.sandbox === true
-      || key.includes("sandbox") || key.includes("test") || key.includes("develop");
-    return isDev
-      ? "https://api.develop.accept.blue/api/v2"
-      : "https://api.accept.blue/api/v2";
+  /**
+   * NMI Payment API endpoint. Sandbox and production share the same host — the
+   * account behind the Security Key determines test vs. live. NMI_API_URL allows
+   * the local integration-test harness to point at a sandbox/mock host.
+   */
+  private getApiUrl(_config: GatewayConfig): string {
+    return process.env.NMI_API_URL || "https://secure.nmi.com/api/transact.php";
   }
 
-  private getAuthHeader(config: GatewayConfig): string {
-    const sourceKey = config.privateKey || "";
-    const pin = (config.settings as any)?.pin || "";
-    return "Basic " + Buffer.from(`${sourceKey}:${pin}`).toString("base64");
+  /** NMI Query API (read side: vault records, subscriptions). Returns XML. */
+  private getQueryUrl(_config: GatewayConfig): string {
+    return process.env.NMI_QUERY_URL || "https://secure.nmi.com/api/query.php";
   }
 
-  private axiosConfig(config: GatewayConfig) {
+  /**
+   * POST a form-urlencoded request to the NMI Payment API and parse the
+   * url-encoded response into a flat string map.
+   * security_key is always injected from config.privateKey.
+   */
+  private async nmiPost(config: GatewayConfig, params: Record<string, any>): Promise<Record<string, string>> {
+    const body = new URLSearchParams();
+    body.set("security_key", config.privateKey || "");
+    for (const [k, v] of Object.entries(params)) {
+      if (v === undefined || v === null || v === "") continue;
+      body.set(k, String(v));
+    }
+
+    const response = await Axios.post(this.getApiUrl(config), body.toString(), {
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      // NMI returns 200 with response=2/3 for declines/errors; only throw on transport errors.
+      timeout: 30000,
+    });
+
+    const parsed: Record<string, string> = {};
+    new URLSearchParams(typeof response.data === "string" ? response.data : "").forEach((value, key) => {
+      parsed[key] = value;
+    });
+    return parsed;
+  }
+
+  /** NMI: response === "1" means Approved. */
+  private isApproved(resp: Record<string, string>): boolean {
+    return resp.response === "1";
+  }
+
+  private errorText(resp: Record<string, string>): string {
+    return resp.responsetext || resp.response_code || "Transaction was not approved";
+  }
+
+  /** Split a "First Last" display name into NMI first_name / last_name fields. */
+  private splitName(name: string): { first_name?: string; last_name?: string } {
+    const parts = (name || "").trim().split(/\s+/).filter(Boolean);
+    if (parts.length === 0) return {};
+    if (parts.length === 1) return { first_name: parts[0] };
+    return { first_name: parts[0], last_name: parts.slice(1).join(" ") };
+  }
+
+  /** Build NMI billing fields from donationData.person / billing_info. */
+  private billingFields(donationData: any): Record<string, any> {
+    const person = donationData.person || {};
+    const billing = donationData.billing_info || {};
+    const first = billing.first_name || person.firstName || person.first_name;
+    const last = billing.last_name || person.lastName || person.last_name;
+    const email = billing.email || person.email || donationData.email;
     return {
-      headers: {
-        "Authorization": this.getAuthHeader(config),
-        "Content-Type": "application/json"
-      }
+      first_name: first || undefined,
+      last_name: last || undefined,
+      email: email || undefined,
     };
   }
 
   // ─── Webhook Management ───────────────────────────────────
 
   /**
-   * Webhooks are configured in the Control Panel, not via API.
-   * The API docs show webhook CRUD but we'll handle setup in the admin UI.
-   * This method is a no-op placeholder; ensureWebhookExists() is the real entry point.
+   * NMI webhook endpoints + signing keys are configured in the Merchant Portal
+   * (Settings → Webhooks), not via the Payment API. Setup is handled in B1Admin.
    */
   async createWebhookEndpoint(_config: GatewayConfig, _webhookUrl: string): Promise<{ id: string; secret?: string }> {
-    // KingdomFunding webhook creation is done via the Control Panel, not via API.
     return { id: "", secret: "" };
   }
 
   async deleteWebhooksByChurchId(_config: GatewayConfig, _churchId: string): Promise<void> {
-    // No-op: webhooks managed via Control Panel
+    // No-op: webhooks managed via the NMI Merchant Portal.
   }
 
   /**
-   * Verify KingdomFunding webhook signature using HMAC-SHA256.
+   * Verify an NMI webhook signature.
    *
-   * The gateway sends an `X-Signature` header containing the HMAC-SHA256 hash
-   * of the raw request body, using the webhook endpoint's signature key as the secret.
+   * NMI sends a `Webhook-Signature` header of the form `t=<nonce>,s=<hexHmac>`.
+   * The signed string is `<nonce>.<rawBody>` and the HMAC is SHA-256 keyed with
+   * the endpoint's signing key (stored in config.webhookKey).
    *
-   * Webhook event types:
-   *   Transaction: succeeded, updated, declined, error, status
-   *   Batch: closed
+   * IMPORTANT: `body` must be the RAW request body (string). A re-serialized JSON
+   * object will not reproduce the signature. DonateController passes the raw body.
    */
   async verifyWebhookSignature(
     config: GatewayConfig,
     headers: express.Request["headers"],
     body: any
   ): Promise<WebhookResult> {
-    const signatureHeader = (headers["x-signature"] || "") as string;
+    const signatureHeader = (headers["webhook-signature"] || "") as string;
     const webhookSecret = config.webhookKey;
 
-    // No webhook secret configured at all — refuse to process (do not silently accept).
-    // This forces churches to configure the webhook secret in B1Admin before
-    // their Kingdom Funding webhooks can be processed.
+    // No signing key configured — refuse to process (don't silently accept).
     if (!webhookSecret) {
-      console.error("KingdomFunding webhook: no webhook secret configured for this church; rejecting.");
+      console.error("KingdomFunding(NMI) webhook: no signing key configured for this church; rejecting.");
       return { success: false, shouldProcess: false };
     }
-
-    // Secret is configured — signature is REQUIRED on every incoming webhook.
     if (!signatureHeader) {
-      console.error("KingdomFunding webhook: missing X-Signature header; rejecting.");
+      console.error("KingdomFunding(NMI) webhook: missing Webhook-Signature header; rejecting.");
       return { success: false, shouldProcess: false };
     }
 
-    // Verify HMAC-SHA256 signature
-    const rawBody = typeof body === "string" ? body : JSON.stringify(body);
-    const expectedSignature = crypto
+    // Parse `t=<nonce>,s=<sig>`
+    const parts: Record<string, string> = {};
+    for (const seg of signatureHeader.split(",")) {
+      const idx = seg.indexOf("=");
+      if (idx > 0) parts[seg.slice(0, idx).trim()] = seg.slice(idx + 1).trim();
+    }
+    const nonce = parts.t;
+    const provided = parts.s;
+    if (!nonce || !provided) {
+      console.error("KingdomFunding(NMI) webhook: malformed Webhook-Signature header; rejecting.");
+      return { success: false, shouldProcess: false };
+    }
+
+    // The raw request body is preserved by the webhook route (string in production,
+    // Buffer in local dev — see app.ts). NMI signs the exact raw bytes, so we must
+    // hash that raw payload, never a re-serialized object.
+    const rawBody =
+      typeof body === "string"
+        ? body
+        : Buffer.isBuffer(body)
+          ? body.toString("utf8")
+          : JSON.stringify(body ?? {});
+    const expected = crypto
       .createHmac("sha256", webhookSecret)
-      .update(rawBody, "utf-8")
+      .update(`${nonce}.${rawBody}`, "utf-8")
       .digest("hex");
 
-    let signatureMatches = false;
+    let matches = false;
     try {
-      // timingSafeEqual throws if buffers differ in length — guard with try/catch
-      // so an attacker can't probe length via exception behavior.
-      signatureMatches = crypto.timingSafeEqual(
-        Buffer.from(signatureHeader, "hex"),
-        Buffer.from(expectedSignature, "hex")
-      );
+      matches = crypto.timingSafeEqual(Buffer.from(provided, "hex"), Buffer.from(expected, "hex"));
     } catch {
-      signatureMatches = false;
+      matches = false;
     }
-
-    if (!signatureMatches) {
-      console.error("KingdomFunding webhook: Signature mismatch");
+    if (!matches) {
+      console.error("KingdomFunding(NMI) webhook: signature mismatch");
       return { success: false, shouldProcess: false };
     }
 
-    // Parse the event payload
-    // KingdomFunding webhook schema: { type, subType, event, id, timestamp, data }
-    const eventType = body.type || "";          // "succeeded", "declined", "error", "status", "updated", "closed"
-    const eventSubType = body.subType || "";    // "charge", "credit", "refund", "adjust", "void", "settled", etc.
-    const eventCategory = body.event || "";     // "transaction" or "batch"
-    const eventId = body.id || "";
-    const eventData = body.data || {};
+    // NMI webhook payload: { event_id, event_type, event_body }. rawBody is always a
+    // JSON string at this point, so parse it (works for string + Buffer inputs alike).
+    const payload = safeJsonParse(rawBody);
+    const eventType: string = payload?.event_type || "";        // e.g. "transaction.sale.success"
+    const eventId: string = payload?.event_id || "";
+    const eventBody: any = payload?.event_body || {};
 
-    // Determine if we should process this as a donation
-    const isTransactionEvent = eventCategory === "transaction";
-    const shouldProcess = isTransactionEvent && (
-      eventType === "succeeded" ||
-      eventType === "status"    // ACH status updates (settled, returned, etc.)
-    );
+    // event_type is dot-delimited: <category>.<action>.<result>
+    const [category, action, result] = eventType.split(".");
+
+    // Process successful sales and ACH/check status settlements as donations.
+    const isTransaction = category === "transaction";
+    const isCheckStatus = category === "check"; // ACH lifecycle (settled/returned/etc.)
+    const shouldProcess =
+      (isTransaction && (action === "sale" || action === "auth") && result === "success") ||
+      isCheckStatus;
+
+    const txn = eventBody.transaction || eventBody;
+    const transactionId = txn.transaction_id || txn.transactionid || eventBody.transaction_id || eventId;
 
     return {
       success: true,
       shouldProcess,
-      eventType: `${eventType}.${eventSubType}`,  // e.g. "succeeded.charge", "status.settled"
+      eventType,
       eventId,
       eventData: {
-        ...eventData,
-        id: eventData.reference_number || eventData.transaction?.id || eventId,
-        eventType: `${eventType}.${eventSubType}`,
-        eventCategory,
-        // Preserve original fields for downstream processing
-        status: eventData.status,
-        status_code: eventData.status_code,
-        auth_amount: eventData.auth_amount,
-        card_type: eventData.card_type,
-        last_4: eventData.last_4,
+        ...eventBody,
+        id: transactionId,
+        eventType,
+        eventCategory: category,
+        action,
+        result,
+        // Surface common fields downstream code reads (logDonation tolerates missing ones).
+        amount: txn.amount || eventBody.amount,
+        last_4: txn.cc_last_4 || txn.cc_number_masked?.slice(-4) || txn.check_account?.slice(-4),
+        card_type: txn.cc_type || txn.card_type,
       },
     };
   }
@@ -172,547 +234,354 @@ export class KingdomFundingGatewayProvider extends AbstractExperimentalGatewayPr
   // ─── Payment Processing ───────────────────────────────────
 
   /**
-   * Process a one-time charge via KingdomFunding.
+   * Process a one-time charge via NMI.
    *
-   * Card charges use: source = "nonce-{token}" from hosted tokenization
-   * Saved payment method charges use: source = "pm-{paymentMethodId}"
-   * Check/ACH charges route to processBankCharge()
+   * Payment source resolution (in priority order):
+   *   1. saved method  → customer_vault_id (donationData.paymentMethodId or customerId)
+   *   2. Collect.js    → payment_token (donationData.token / donationData.id)
+   *   3. raw bank      → handled by processBankCharge (routing/account fields)
+   *
+   * A Collect.js payment_token carries whether it was a card or ACH, so card and
+   * token-based ACH both flow through here uniformly.
    */
   async processCharge(config: GatewayConfig, donationData: any): Promise<ChargeResult> {
-    if (donationData.type === "bank" || donationData.paymentType === "bank") {
+    // Raw bank fields (no token) route to the dedicated ACH path.
+    const hasRawBank = donationData.routing_number && donationData.account_number;
+    if ((donationData.type === "bank" || donationData.paymentType === "bank") && hasRawBank) {
       return this.processBankCharge(config, donationData);
     }
 
     try {
-      const baseUrl = this.getBaseUrl(config);
-
-      // Determine the source: nonce token, saved payment method, or raw card token
-      let source = "";
-      if (donationData.paymentMethodId) {
-        source = `pm-${donationData.paymentMethodId}`;
-      } else if (donationData.token || donationData.id) {
-        const token = donationData.token || donationData.id;
-        source = token.startsWith("nonce-") ? token : `nonce-${token}`;
-      }
-
-      if (!source) {
-        return { success: false, transactionId: "", data: { error: "Missing payment token or payment method" } };
-      }
-
-      const payload: any = {
-        amount: donationData.amount,
-        source,
-        name: donationData.name || donationData.person?.name || "",
+      const params: Record<string, any> = {
+        type: "sale",
+        amount: this.formatAmount(donationData.amount),
+        ...this.billingFields(donationData),
       };
 
-      // Add expiry data if provided (required for nonce charges)
-      // Normalize: expiry_month as integer 1-12, expiry_year as 4-digit integer
-      if (donationData.expiry_month) payload.expiry_month = Number(donationData.expiry_month);
-      if (donationData.expiry_year) {
-        let ey = Number(donationData.expiry_year);
-        if (ey > 0 && ey < 100) ey += 2000;
-        payload.expiry_year = ey;
-      }
-      if (donationData.avs_zip) payload.avs_zip = donationData.avs_zip;
+      const vaultId = donationData.paymentMethodId || (donationData.customerId && !donationData.token ? donationData.customerId : undefined);
+      const token = donationData.token || (isLikelyToken(donationData.id) ? donationData.id : undefined);
 
-      // Add billing info if available
-      if (donationData.billing_info || donationData.person) {
-        const person = donationData.person || {};
-        payload.billing_info = donationData.billing_info || {
-          first_name: person.firstName || person.first_name || "",
-          last_name: person.lastName || person.last_name || "",
-          email: person.email || "",
-        };
+      if (vaultId) {
+        params.customer_vault_id = vaultId;
+      } else if (token) {
+        params.payment_token = token;
+      } else {
+        return { success: false, transactionId: "", data: { error: "Missing payment token or saved payment method" } };
       }
 
-      // Add customer reference if available (Accept Blue expects numeric customer_id)
-      if (donationData.customerId) {
-        const cid = Number(donationData.customerId);
-        payload.customer_id = isNaN(cid) ? donationData.customerId : cid;
-      }
+      if (donationData.orderId) params.orderid = donationData.orderId;
 
-      const response = await Axios.post(
-        `${baseUrl}/transactions/charge`,
-        payload,
-        this.axiosConfig(config)
-      );
+      const resp = await this.nmiPost(config, params);
 
-      const result = response.data;
-
-      if (result.status === "Approved" || result.status_code === "A") {
+      if (this.isApproved(resp)) {
         return {
           success: true,
-          transactionId: String(result.reference_number || result.transaction?.id || ""),
+          transactionId: resp.transactionid || "",
           data: {
-            ...result,
+            ...resp,
             status: "active",
-            reference_number: result.reference_number,
-            auth_amount: result.auth_amount,
-            card_type: result.card_type,
-            last_4: result.last_4,
-          }
+            reference_number: resp.transactionid,
+            auth_amount: params.amount,
+            authcode: resp.authcode,
+            last_4: resp.cc_number?.slice(-4),
+            card_type: resp.cc_type,
+          },
         };
       }
 
       return {
         success: false,
         transactionId: "",
-        data: { error: result.error_message || result.error_details || "Charge declined", ...result }
+        data: { error: this.errorText(resp), ...resp },
       };
     } catch (error: any) {
-      const errData = error.response?.data || {};
-      const status = error.response?.status;
-      // Accept Blue sometimes returns HTML error pages (e.g. nginx 500/502/503)
-      const isHtmlError = typeof errData === "string" && errData.includes("<html");
-      const errorMsg = isHtmlError
-        ? `Accept Blue server error (HTTP ${status}). Please try again.`
-        : (errData.error_message || errData.error_details || error.message || "Charge failed");
-      console.error("KingdomFunding processCharge error:", JSON.stringify({ status, isHtmlError, message: errorMsg }));
-      return {
-        success: false,
-        transactionId: "",
-        data: { error: errorMsg }
-      };
+      const msg = error.response?.data || error.message || "Charge failed";
+      console.error("KingdomFunding(NMI) processCharge error:", typeof msg === "string" ? msg : JSON.stringify(msg));
+      return { success: false, transactionId: "", data: { error: "Charge failed. Please try again." } };
     }
   }
 
   /**
-   * Process a bank/ACH charge.
-   * KingdomFunding handles check charges on the same /transactions/charge endpoint
-   * with routing_number, account_number, account_type, sec_code fields.
-   *
-   * When using a saved check payment method, use source = "pm-{id}".
-   * For tokenized bank data, the frontend should provide routing/account details
-   * or a nonce token.
+   * Process a bank/ACH charge from RAW routing/account details.
+   * (Token-based ACH goes through processCharge with a payment_token.)
    */
   private async processBankCharge(config: GatewayConfig, donationData: any): Promise<ChargeResult> {
     try {
-      const baseUrl = this.getBaseUrl(config);
-
-      const payload: any = {
-        amount: donationData.amount,
-        name: donationData.name || donationData.person?.name || "",
+      const params: Record<string, any> = {
+        type: "sale",
+        amount: this.formatAmount(donationData.amount),
+        payment: "check",
+        checkname: donationData.name || donationData.person?.name || "",
+        checkaba: donationData.routing_number,
+        checkaccount: donationData.account_number,
+        account_type: donationData.account_type || "checking", // checking | savings
+        account_holder_type: donationData.account_holder_type || "personal", // personal | business
+        sec_code: donationData.sec_code || "WEB", // PPD | WEB | CCD | TEL
+        ...this.billingFields(donationData),
       };
 
       if (donationData.paymentMethodId) {
-        // Charge a saved check payment method
-        payload.source = `pm-${donationData.paymentMethodId}`;
-      } else if (donationData.token || donationData.id) {
-        // Tokenized bank data
-        const token = donationData.token || donationData.id;
-        payload.source = token.startsWith("nonce-") ? token : `nonce-${token}`;
-      } else if (donationData.routing_number && donationData.account_number) {
-        // Raw bank fields
-        payload.routing_number = donationData.routing_number;
-        payload.account_number = donationData.account_number;
-        payload.account_type = donationData.account_type || "checking";
-        payload.sec_code = donationData.sec_code || "WEB";
-      } else {
-        return { success: false, transactionId: "", data: { error: "Missing bank payment data" } };
+        // Saved ACH method → charge the vault record instead of raw fields.
+        delete params.payment;
+        delete params.checkname;
+        delete params.checkaba;
+        delete params.checkaccount;
+        delete params.account_type;
+        delete params.account_holder_type;
+        delete params.sec_code;
+        params.customer_vault_id = donationData.paymentMethodId;
       }
 
-      if (donationData.customerId) {
-        payload.customer_id = donationData.customerId;
-      }
+      const resp = await this.nmiPost(config, params);
 
-      const response = await Axios.post(
-        `${baseUrl}/transactions/charge`,
-        payload,
-        this.axiosConfig(config)
-      );
-
-      const result = response.data;
-
-      if (result.status === "Approved" || result.status_code === "A") {
+      if (this.isApproved(resp)) {
         return {
           success: true,
-          transactionId: String(result.reference_number || result.transaction?.id || ""),
-          data: {
-            ...result,
-            status: "active",
-            reference_number: result.reference_number,
-            auth_amount: result.auth_amount,
-          }
+          transactionId: resp.transactionid || "",
+          data: { ...resp, status: "active", reference_number: resp.transactionid, auth_amount: params.amount },
         };
       }
-
-      return {
-        success: false,
-        transactionId: "",
-        data: { error: result.error_message || result.error_details || "ACH charge declined", ...result }
-      };
+      return { success: false, transactionId: "", data: { error: this.errorText(resp), ...resp } };
     } catch (error: any) {
-      const errData = error.response?.data || {};
-      console.error("KingdomFunding processBankCharge error:", errData.error_message || error.message);
-      return {
-        success: false,
-        transactionId: "",
-        data: { error: errData.error_message || errData.error_details || error.message || "ACH charge failed" }
-      };
+      console.error("KingdomFunding(NMI) processBankCharge error:", error.message);
+      return { success: false, transactionId: "", data: { error: "ACH charge failed. Please try again." } };
     }
   }
 
-  // ─── Recurring Schedules ──────────────────────────────────
+  /** NMI expects amounts as a decimal string with 2 places, e.g. "10.00". */
+  private formatAmount(amount: any): string {
+    const n = Number(amount);
+    return (isNaN(n) ? 0 : n).toFixed(2);
+  }
+
+  // ─── Recurring Subscriptions ──────────────────────────────
 
   /**
-   * Map our frontend interval format to KingdomFunding frequency strings.
-   * KingdomFunding supports: daily, weekly, biweekly, monthly, bimonthly, quarterly, biannually, annually
+   * Map our frontend interval format to NMI recurring frequency fields.
+   * NMI uses EITHER day_frequency OR (month_frequency + day_of_month) — never both.
    */
-  private mapIntervalToFrequency(interval: any): string {
-    if (!interval) return "monthly";
+  private mapIntervalToNmi(interval: any, anchorDate: Date): Record<string, any> {
+    const str = (typeof interval === "string" ? interval : interval?.interval || interval?.frequency || "").toLowerCase();
+    const dayOfMonth = anchorDate.getDate();
 
-    // Handle string format directly
-    const str = typeof interval === "string" ? interval : interval.interval || interval.frequency || "";
-    const lower = str.toLowerCase();
+    switch (str) {
+      case "daily": return { day_frequency: 1 };
+      case "one_week": case "weekly": return { day_frequency: 7 };
+      case "two_week": case "biweekly": return { day_frequency: 14 };
+      case "one_month": case "monthly": return { month_frequency: 1, day_of_month: dayOfMonth };
+      case "two_month": case "bimonthly": return { month_frequency: 2, day_of_month: dayOfMonth };
+      case "three_month": case "quarterly": return { month_frequency: 3, day_of_month: dayOfMonth };
+      case "six_month": case "biannually": return { month_frequency: 6, day_of_month: dayOfMonth };
+      case "one_year": case "annual": case "annually": return { month_frequency: 12, day_of_month: dayOfMonth };
+      default: return { month_frequency: 1, day_of_month: dayOfMonth };
+    }
+  }
 
-    const map: Record<string, string> = {
-      "one_week": "weekly",
-      "two_week": "biweekly",
-      "one_month": "monthly",
-      "two_month": "bimonthly",
-      "three_month": "quarterly",
-      "six_month": "biannually",
-      "one_year": "annually",
-      // Direct KingdomFunding values pass through
-      "daily": "daily",
-      "weekly": "weekly",
-      "biweekly": "biweekly",
-      "monthly": "monthly",
-      "bimonthly": "bimonthly",
-      "quarterly": "quarterly",
-      "biannually": "biannually",
-      "annually": "annually",
-      // Uppercase format fallback
-      "DAILY": "daily",
-      "WEEKLY": "weekly",
-      "MONTHLY": "monthly",
-      "QUARTERLY": "quarterly",
-      "ANNUAL": "annually",
-    };
-
-    return map[lower] || map[str] || "monthly";
+  /** Format a Date as NMI's YYYYMMDD start_date. */
+  private nmiDate(d: Date): string {
+    const y = d.getFullYear();
+    const m = String(d.getMonth() + 1).padStart(2, "0");
+    const day = String(d.getDate()).padStart(2, "0");
+    return `${y}${m}${day}`;
   }
 
   /**
-   * Create a recurring schedule in KingdomFunding.
+   * Create a recurring subscription in NMI.
    *
-   * KingdomFunding uses a single-step model: POST /customers/:id/recurring-schedules
-   * Required: title, amount, payment_method_id, frequency, next_run_date
-   *
-   * The customer and payment method must exist before creating a schedule.
-   * If no customerId is provided, we'll create one first.
+   * Collect.js tokens are single-use, so recurring requires a vaulted method:
+   *   1. Vault the payment method (add_customer with payment_token / raw bank) → customer_vault_id
+   *   2. If it starts today, charge the vault immediately
+   *   3. add_subscription against the customer_vault_id with a future start_date
    */
   async createSubscription(config: GatewayConfig, subscriptionData: any): Promise<SubscriptionResult> {
     try {
-      const baseUrl = this.getBaseUrl(config);
       const name = subscriptionData.name || subscriptionData.person?.name?.display || subscriptionData.person?.name || "Donor";
-      const email = subscriptionData.email || subscriptionData.person?.email || "";
-      const token = subscriptionData.token || subscriptionData.id;
-      // Only treat as nonce if it's not a numeric saved-PM ID
-      const isSavedPmId = token && /^\d+$/.test(String(token));
-      const nonceSource = (!isSavedPmId && token) ? (String(token).startsWith("nonce-") ? String(token) : `nonce-${token}`) : "";
+      const amount = this.formatAmount(subscriptionData.amount);
+      const token = subscriptionData.token || (isLikelyToken(subscriptionData.id) ? subscriptionData.id : undefined);
+      const isBank = subscriptionData.type === "bank" || (subscriptionData.routing_number && subscriptionData.account_number);
 
-      // Normalize expiry year to 4-digit (accept.blue requires 2020-9999)
-      let expiryYear = subscriptionData.expiry_year ? Number(subscriptionData.expiry_year) : undefined;
-      if (expiryYear && expiryYear < 100) expiryYear += 2000;
-      const expiryMonth = subscriptionData.expiry_month ? Number(subscriptionData.expiry_month) : undefined;
-
-      // Step 1: Determine if the recurring donation starts today
-      let startsToday = false;
+      // Determine start timing.
+      let startsToday = true;
+      let anchorDate = new Date();
       if (subscriptionData.billing_cycle_anchor) {
         let anchorMs = subscriptionData.billing_cycle_anchor;
         if (anchorMs < 10000000000) anchorMs = anchorMs * 1000;
-        const anchorDate = new Date(anchorMs);
+        anchorDate = new Date(anchorMs);
         const today = new Date();
-        startsToday = anchorDate.toISOString().split("T")[0] === today.toISOString().split("T")[0]
-          || anchorDate <= today;
-      } else {
-        startsToday = true; // No anchor = starts now
+        startsToday =
+          anchorDate.toISOString().split("T")[0] === today.toISOString().split("T")[0] || anchorDate <= today;
       }
 
-      let customerId = subscriptionData.customerId;
-      let referenceNumber: number | null = null;
-
-      // Detect ACH/bank flow
-      const isBank = subscriptionData.type === "bank"
-        || (subscriptionData.routing_number && subscriptionData.account_number);
-
-      // Step 2: If starts today, charge immediately first
-      if (startsToday && (nonceSource || isBank)) {
-        const chargePayload: any = {
-          amount: subscriptionData.amount,
-          name,
-        };
-
-        if (isBank) {
-          chargePayload.routing_number = subscriptionData.routing_number;
-          chargePayload.account_number = subscriptionData.account_number;
-          chargePayload.account_type = subscriptionData.account_type || "checking";
-          chargePayload.sec_code = subscriptionData.sec_code || "WEB";
-        } else {
-          chargePayload.source = nonceSource;
-          if (expiryMonth) chargePayload.expiry_month = expiryMonth;
-          if (expiryYear) chargePayload.expiry_year = expiryYear;
-        }
-
-        const chargeResponse = await Axios.post(
-          `${baseUrl}/transactions/charge`,
-          chargePayload,
-          this.axiosConfig(config)
-        );
-
-        referenceNumber = chargeResponse.data?.reference_number;
-        if (!referenceNumber) {
-          const errMsg = chargeResponse.data?.error_message || "Initial charge failed";
-          console.error("KingdomFunding: Initial recurring charge failed", chargeResponse.data);
-          return { success: false, subscriptionId: "", data: { error: errMsg } };
-        }
-      }
-
-      // Step 3: Create customer
-      if (!customerId) {
-        customerId = await this.createCustomer(config, email, name);
-      }
-
-      // Step 4: Create payment method on the customer
-      let paymentMethodId = subscriptionData.paymentMethodId;
-
-      // If the incoming id is a numeric Accept Blue PM ID (saved card), use it directly
-      const rawId = subscriptionData.id ? String(subscriptionData.id) : "";
-      if (!paymentMethodId && rawId && /^\d+$/.test(rawId) && !rawId.startsWith("nonce-")) {
-        paymentMethodId = Number(rawId);
-      }
-
-      if (!paymentMethodId) {
-        const pmPayload: any = {};
-
-        if (referenceNumber) {
-          // Create payment method from the transaction reference (works for both card and ACH)
-          pmPayload.source = `ref-${referenceNumber}`;
-          if (!isBank && expiryMonth) pmPayload.expiry_month = expiryMonth;
-          if (!isBank && expiryYear) pmPayload.expiry_year = expiryYear;
-        } else if (isBank) {
-          // ACH future-dated subscription — create PM directly from routing/account
-          pmPayload.routing_number = subscriptionData.routing_number;
-          pmPayload.account_number = subscriptionData.account_number;
-          pmPayload.account_type = subscriptionData.account_type || "checking";
-        } else if (nonceSource) {
-          // Create payment method from the nonce
-          pmPayload.source = nonceSource;
-          if (expiryMonth) pmPayload.expiry_month = expiryMonth;
-          if (expiryYear) pmPayload.expiry_year = expiryYear;
-        }
-
-        if (name) pmPayload.name = name;
-
-        try {
-          const pmResponse = await Axios.post(
-            `${baseUrl}/customers/${customerId}/payment-methods`,
-            pmPayload,
-            this.axiosConfig(config)
-          );
-          paymentMethodId = pmResponse.data?.id;
-        } catch (pmErr: any) {
-          // If the payment method already exists for this customer, reuse it
-          const existingPm = pmErr.response?.data?.error_details?.payment_method;
-          if (existingPm?.id) {
-            paymentMethodId = existingPm.id;
-          } else {
-            console.error("KingdomFunding: Failed to create payment method", pmErr.response?.data || pmErr.message);
-            return { success: false, subscriptionId: "", data: { error: "Failed to save payment method for recurring donation" } };
-          }
-        }
-
-        if (!paymentMethodId) {
-          console.error("KingdomFunding: No payment method ID obtained");
+      // Step 1: obtain a vault id (reuse if a saved method was provided).
+      let customerVaultId: string | undefined = subscriptionData.paymentMethodId || subscriptionData.customerId;
+      if (!customerVaultId) {
+        customerVaultId = await this.vaultPaymentMethod(config, { token, isBank, name, subscriptionData });
+        if (!customerVaultId) {
           return { success: false, subscriptionId: "", data: { error: "Failed to save payment method for recurring donation" } };
         }
       }
 
-      // Step 5: Calculate next_run_date for the schedule
-      // If we already charged today, next run should be the next cycle date
-      const frequency = this.mapIntervalToFrequency(subscriptionData.interval);
-      let nextRunDate: string;
-
+      // Step 2: if it starts today, charge the vault now.
+      let initialTxnId: string | undefined;
       if (startsToday) {
-        // Already charged today, schedule starts on the next cycle
-        const next = new Date();
-        switch (frequency) {
-          case "daily": next.setDate(next.getDate() + 1); break;
-          case "weekly": next.setDate(next.getDate() + 7); break;
-          case "biweekly": next.setDate(next.getDate() + 14); break;
-          case "monthly": next.setMonth(next.getMonth() + 1); break;
-          case "bimonthly": next.setMonth(next.getMonth() + 2); break;
-          case "quarterly": next.setMonth(next.getMonth() + 3); break;
-          case "biannually": next.setMonth(next.getMonth() + 6); break;
-          case "annually": next.setFullYear(next.getFullYear() + 1); break;
-          default: next.setMonth(next.getMonth() + 1); break;
+        const chargeResp = await this.nmiPost(config, {
+          type: "sale",
+          amount,
+          customer_vault_id: customerVaultId,
+          ...this.billingFields(subscriptionData),
+        });
+        if (!this.isApproved(chargeResp)) {
+          return { success: false, subscriptionId: "", data: { error: this.errorText(chargeResp) } };
         }
-        nextRunDate = next.toISOString().split("T")[0];
-      } else {
-        // Starts in the future
-        let anchorMs = subscriptionData.billing_cycle_anchor;
-        if (anchorMs < 10000000000) anchorMs = anchorMs * 1000;
-        nextRunDate = new Date(anchorMs).toISOString().split("T")[0];
+        initialTxnId = chargeResp.transactionid;
       }
 
-      // Step 6: Create the recurring schedule
-      const schedulePayload = {
-        title: `Recurring Donation $${subscriptionData.amount}`,
-        amount: subscriptionData.amount,
-        payment_method_id: paymentMethodId,
-        frequency,
-        next_run_date: nextRunDate,
-        num_left: 0,  // 0 = ongoing
-        active: true,
-      };
+      // Step 3: compute the next run date, then add the subscription.
+      const nextRun = startsToday ? this.advance(anchorDate.getTime() <= Date.now() ? new Date() : anchorDate, subscriptionData.interval) : anchorDate;
+      const freq = this.mapIntervalToNmi(subscriptionData.interval, nextRun);
 
-      const response = await Axios.post(
-        `${baseUrl}/customers/${customerId}/recurring-schedules`,
-        schedulePayload,
-        this.axiosConfig(config)
-      );
+      const subResp = await this.nmiPost(config, {
+        recurring: "add_subscription",
+        customer_vault_id: customerVaultId,
+        plan_amount: amount,
+        plan_payments: 0, // 0 = continue until cancelled
+        start_date: this.nmiDate(nextRun),
+        ...freq,
+      });
 
-      const schedule = response.data;
-      const scheduleId = String(schedule.id || "");
-
-      if (!scheduleId) {
-        console.error("KingdomFunding: Recurring schedule created but no ID returned", schedule);
-        return { success: false, subscriptionId: "", data: { error: "Recurring schedule creation failed" } };
+      if (!this.isApproved(subResp) || !subResp.subscription_id) {
+        return { success: false, subscriptionId: "", data: { error: this.errorText(subResp) || "Recurring schedule creation failed" } };
       }
 
       return {
         success: true,
-        subscriptionId: scheduleId,
+        subscriptionId: subResp.subscription_id,
         data: {
-          ...schedule,
+          ...subResp,
           status: "active",
-          customerId: String(customerId),
-          paymentMethodId: String(paymentMethodId),
-          frequency,
-          nextRunDate,
-          initialChargeRef: referenceNumber ? String(referenceNumber) : undefined,
-        }
+          customerId: String(customerVaultId),
+          paymentMethodId: String(customerVaultId),
+          nextRunDate: this.nmiDate(nextRun),
+          initialChargeRef: initialTxnId,
+        },
       };
     } catch (error: any) {
-      const errData = error.response?.data || {};
-      console.error("KingdomFunding createSubscription error:", errData.error_message || errData.message || error.message);
-      if (error.response?.data) console.error("KingdomFunding createSubscription response data:", JSON.stringify(error.response.data));
-      return {
-        success: false,
-        subscriptionId: "",
-        data: { error: errData.error_message || errData.message || error.message || "Subscription creation failed" }
-      };
+      console.error("KingdomFunding(NMI) createSubscription error:", error.message);
+      return { success: false, subscriptionId: "", data: { error: "Subscription creation failed. Please try again." } };
     }
+  }
+
+  /**
+   * Create an NMI Customer Vault record from a token or raw bank details.
+   * Returns the customer_vault_id (we generate and supply it so it's stable/known).
+   */
+  private async vaultPaymentMethod(
+    config: GatewayConfig,
+    opts: { token?: string; isBank?: boolean; name?: string; subscriptionData?: any }
+  ): Promise<string | undefined> {
+    const vaultId = crypto.randomUUID();
+    const params: Record<string, any> = {
+      customer_vault: "add_customer",
+      customer_vault_id: vaultId,
+      ...this.splitName(opts.name || ""),
+      email: opts.subscriptionData?.email || opts.subscriptionData?.person?.email || undefined,
+    };
+
+    if (opts.token) {
+      params.payment_token = opts.token;
+    } else if (opts.isBank && opts.subscriptionData) {
+      params.payment = "check";
+      params.checkname = opts.name || "";
+      params.checkaba = opts.subscriptionData.routing_number;
+      params.checkaccount = opts.subscriptionData.account_number;
+      params.account_type = opts.subscriptionData.account_type || "checking";
+      params.sec_code = opts.subscriptionData.sec_code || "WEB";
+    } else {
+      return undefined;
+    }
+
+    const resp = await this.nmiPost(config, params);
+    if (!this.isApproved(resp)) {
+      console.error("KingdomFunding(NMI) vaultPaymentMethod failed:", this.errorText(resp));
+      return undefined;
+    }
+    // NMI echoes back the vault id we supplied (or its own in customer_vault_id).
+    return resp.customer_vault_id || vaultId;
+  }
+
+  /** Advance a date by one interval (used to schedule the next run after charging today). */
+  private advance(from: Date, interval: any): Date {
+    const next = new Date(from);
+    const str = (typeof interval === "string" ? interval : interval?.interval || "").toLowerCase();
+    switch (str) {
+      case "daily": next.setDate(next.getDate() + 1); break;
+      case "one_week": case "weekly": next.setDate(next.getDate() + 7); break;
+      case "two_week": case "biweekly": next.setDate(next.getDate() + 14); break;
+      case "two_month": case "bimonthly": next.setMonth(next.getMonth() + 2); break;
+      case "three_month": case "quarterly": next.setMonth(next.getMonth() + 3); break;
+      case "six_month": case "biannually": next.setMonth(next.getMonth() + 6); break;
+      case "one_year": case "annual": case "annually": next.setFullYear(next.getFullYear() + 1); break;
+      default: next.setMonth(next.getMonth() + 1); break; // monthly
+    }
+    return next;
   }
 
   async updateSubscription(config: GatewayConfig, subscriptionData: any): Promise<SubscriptionResult> {
     try {
-      const baseUrl = this.getBaseUrl(config);
-      const scheduleId = subscriptionData.subscriptionId || subscriptionData.id;
-
-      if (!scheduleId) {
-        return { success: false, subscriptionId: "", data: { error: "Missing recurring schedule ID" } };
+      const subscriptionId = subscriptionData.subscriptionId || subscriptionData.id;
+      if (!subscriptionId) {
+        return { success: false, subscriptionId: "", data: { error: "Missing subscription ID" } };
       }
 
-      const updatePayload: any = {};
-      if (subscriptionData.amount) updatePayload.amount = subscriptionData.amount;
-      if (subscriptionData.interval) updatePayload.frequency = this.mapIntervalToFrequency(subscriptionData.interval);
-      if (subscriptionData.next_run_date) updatePayload.next_run_date = subscriptionData.next_run_date;
-      if (subscriptionData.active !== undefined) updatePayload.active = subscriptionData.active;
-      if (subscriptionData.paymentMethodId) updatePayload.payment_method_id = subscriptionData.paymentMethodId;
+      const params: Record<string, any> = { recurring: "update_subscription", subscription_id: subscriptionId };
+      if (subscriptionData.amount) params.plan_amount = this.formatAmount(subscriptionData.amount);
+      if (subscriptionData.interval) Object.assign(params, this.mapIntervalToNmi(subscriptionData.interval, new Date()));
 
-      const response = await Axios.patch(
-        `${baseUrl}/recurring-schedules/${scheduleId}`,
-        updatePayload,
-        this.axiosConfig(config)
-      );
-
-      return {
-        success: true,
-        subscriptionId: String(scheduleId),
-        data: response.data
-      };
+      const resp = await this.nmiPost(config, params);
+      if (!this.isApproved(resp)) {
+        return { success: false, subscriptionId: String(subscriptionId), data: { error: this.errorText(resp) } };
+      }
+      return { success: true, subscriptionId: String(subscriptionId), data: resp };
     } catch (error: any) {
-      const errData = error.response?.data || {};
-      console.error("KingdomFunding updateSubscription error:", errData.error_message || error.message);
-      return {
-        success: false,
-        subscriptionId: subscriptionData.subscriptionId || "",
-        data: { error: errData.error_message || error.message || "Subscription update failed" }
-      };
+      console.error("KingdomFunding(NMI) updateSubscription error:", error.message);
+      return { success: false, subscriptionId: subscriptionData.subscriptionId || "", data: { error: "Subscription update failed" } };
     }
   }
 
   async cancelSubscription(config: GatewayConfig, subscriptionId: string, _reason?: string): Promise<void> {
-    try {
-      const baseUrl = this.getBaseUrl(config);
-      // Deactivate by setting active: false
-      await Axios.patch(
-        `${baseUrl}/recurring-schedules/${subscriptionId}`,
-        { active: false },
-        this.axiosConfig(config)
-      );
-    } catch (error: any) {
-      console.error("KingdomFunding cancelSubscription error:", {
-        subscriptionId,
-        status: error.response?.status,
-        data: error.response?.data,
-        message: error.message
-      });
-      throw new Error(error.response?.data?.error_message || error.message || "Failed to cancel subscription");
+    const resp = await this.nmiPost(config, { recurring: "delete_subscription", subscription_id: subscriptionId });
+    if (!this.isApproved(resp)) {
+      console.error("KingdomFunding(NMI) cancelSubscription error:", { subscriptionId, error: this.errorText(resp) });
+      throw new Error(this.errorText(resp) || "Failed to cancel subscription");
     }
   }
 
   // ─── Refunds ──────────────────────────────────────────────
 
   /**
-   * Refund a previously settled transaction.
-   * POST /transactions/refund — body: { reference_number, amount? }
-   * Omit amount for full refund.
+   * Refund (settled) or void (unsettled) a transaction.
+   * We attempt a refund; the caller can pass type:"void" to force a void.
+   * Omit amount for a full refund.
    */
   async processRefund(config: GatewayConfig, refundData: any): Promise<ChargeResult> {
     try {
-      const baseUrl = this.getBaseUrl(config);
-
-      const payload: any = {
-        reference_number: parseInt(refundData.reference_number || refundData.transactionId, 10),
-      };
-
-      // If amount provided, partial refund; otherwise full refund
-      if (refundData.amount) {
-        payload.amount = refundData.amount;
+      const transactionId = refundData.transactionId || refundData.reference_number;
+      if (!transactionId) {
+        return { success: false, transactionId: "", data: { error: "Missing transaction ID for refund" } };
       }
 
-      const response = await Axios.post(
-        `${baseUrl}/transactions/refund`,
-        payload,
-        this.axiosConfig(config)
-      );
+      const type = refundData.type === "void" ? "void" : "refund";
+      const params: Record<string, any> = { type, transactionid: transactionId };
+      if (type === "refund" && refundData.amount) params.amount = this.formatAmount(refundData.amount);
 
-      const result = response.data;
-
-      if (result.status === "Approved" || result.status_code === "A") {
-        return {
-          success: true,
-          transactionId: String(result.reference_number || ""),
-          data: result
-        };
+      const resp = await this.nmiPost(config, params);
+      if (this.isApproved(resp)) {
+        return { success: true, transactionId: resp.transactionid || String(transactionId), data: resp };
       }
-
-      return {
-        success: false,
-        transactionId: "",
-        data: { error: result.error_message || "Refund failed", ...result }
-      };
+      return { success: false, transactionId: "", data: { error: this.errorText(resp), ...resp } };
     } catch (error: any) {
-      const errData = error.response?.data || {};
-      console.error("KingdomFunding processRefund error:", errData.error_message || error.message);
-      return {
-        success: false,
-        transactionId: "",
-        data: { error: errData.error_message || error.message || "Refund failed" }
-      };
+      console.error("KingdomFunding(NMI) processRefund error:", error.message);
+      return { success: false, transactionId: "", data: { error: "Refund failed. Please try again." } };
     }
   }
 
@@ -720,7 +589,7 @@ export class KingdomFundingGatewayProvider extends AbstractExperimentalGatewayPr
 
   /**
    * Calculate transaction fees using KF-specific settings (flatRateKF / transFeeKF).
-   * Fee calculation is our own logic, not provider-dependent.
+   * Fee logic is our own, not gateway-dependent — carried over unchanged.
    */
   async calculateFees(amount: number, churchId: string, _currency?: string): Promise<number> {
     let customFixedFee: number | null = null;
@@ -733,7 +602,7 @@ export class KingdomFundingGatewayProvider extends AbstractExperimentalGatewayPr
         if (data?.flatRateKF !== null && data?.flatRateKF !== undefined && data?.flatRateKF !== "") customFixedFee = +data.flatRateKF;
         if (data?.transFeeKF !== null && data?.transFeeKF !== undefined && data?.transFeeKF !== "") customPercentFee = +data.transFeeKF / 100;
       } catch (err) {
-        console.warn("KingdomFunding: Failed to load fee settings, using defaults", err);
+        console.warn("KingdomFunding(NMI): Failed to load fee settings, using defaults", err);
       }
     }
 
@@ -742,256 +611,204 @@ export class KingdomFundingGatewayProvider extends AbstractExperimentalGatewayPr
     return Math.round(((amount + fixedFee) / (1 - percentFee) - amount) * 100) / 100;
   }
 
-  // ─── Customer Management ──────────────────────────────────
+  // ─── Customer & Payment Method Management ─────────────────
 
   /**
-   * Create a customer in KingdomFunding.
-   * POST /customers — body: { identifier, email, first_name, last_name, ... }
-   * Returns the customer ID (integer).
+   * Create a bare Customer Vault record (contact info only).
+   * Payment methods are attached separately via attachPaymentMethod (add_billing).
+   * Returns the customer_vault_id.
    */
   async createCustomer(config: GatewayConfig, email: string, name: string): Promise<string> {
-    try {
-      const baseUrl = this.getBaseUrl(config);
-      const nameParts = (name || "").split(" ");
-      const firstName = nameParts[0] || "";
-      const lastName = nameParts.slice(1).join(" ") || "";
-
-      const payload = {
-        identifier: email || name || "donor",
-        email: email || undefined,
-        first_name: firstName || undefined,
-        last_name: lastName || undefined,
-      };
-
-      const response = await Axios.post(
-        `${baseUrl}/customers`,
-        payload,
-        this.axiosConfig(config)
-      );
-
-      const customerId = response.data?.id;
-      if (!customerId) {
-        throw new Error("Customer creation returned no ID");
-      }
-
-      return String(customerId);
-    } catch (error: any) {
-      console.error("KingdomFunding createCustomer error:", error.response?.data || error.message);
-      throw new Error(error.response?.data?.error_message || error.message || "Failed to create customer");
+    const vaultId = crypto.randomUUID();
+    const resp = await this.nmiPost(config, {
+      customer_vault: "add_customer",
+      customer_vault_id: vaultId,
+      email: email || undefined,
+      ...this.splitName(name),
+    });
+    if (!this.isApproved(resp)) {
+      throw new Error(this.errorText(resp) || "Failed to create customer");
     }
+    return resp.customer_vault_id || vaultId;
   }
+
+  /**
+   * Attach a payment method to a customer vault record.
+   * - With options.customerId → add_billing to that vault (supports multiple methods).
+   * - Without → add_customer creating a new vault record from the token/bank.
+   * Returns an object with `.id` (the id callers persist) and `customer_vault_id`.
+   */
+  async attachPaymentMethod(config: GatewayConfig, paymentMethodId: string, options: any): Promise<any> {
+    const token = options.source || options.token || (isLikelyToken(paymentMethodId) ? paymentMethodId : undefined);
+    const customerId = options.customerId;
+
+    const methodParams: Record<string, any> = {};
+    if (token) {
+      methodParams.payment_token = token;
+    } else if (options.routing_number) {
+      methodParams.payment = "check";
+      methodParams.checkname = options.name || "";
+      methodParams.checkaba = options.routing_number;
+      methodParams.checkaccount = options.account_number;
+      methodParams.account_type = options.account_type || "checking";
+      methodParams.sec_code = options.sec_code || "WEB";
+    } else {
+      throw new Error("attachPaymentMethod requires a payment_token or bank details");
+    }
+    Object.assign(methodParams, this.splitName(options.name || ""));
+
+    let resp: Record<string, string>;
+    let vaultId: string;
+    let billingId: string | undefined;
+
+    if (customerId) {
+      billingId = crypto.randomUUID();
+      resp = await this.nmiPost(config, {
+        customer_vault: "add_billing",
+        customer_vault_id: customerId,
+        billing_id: billingId,
+        ...methodParams,
+      });
+      vaultId = customerId;
+    } else {
+      vaultId = crypto.randomUUID();
+      resp = await this.nmiPost(config, {
+        customer_vault: "add_customer",
+        customer_vault_id: vaultId,
+        ...methodParams,
+      });
+      vaultId = resp.customer_vault_id || vaultId;
+    }
+
+    if (!this.isApproved(resp)) {
+      throw new Error(this.errorText(resp) || "Failed to save payment method");
+    }
+
+    // The persisted "payment method id" is the vault id (one method per donor vault by default).
+    return { id: vaultId, customer_vault_id: vaultId, billing_id: billingId, ...resp };
+  }
+
+  /**
+   * Remove a saved payment method. With a billing id we delete just that billing
+   * record; otherwise we delete the whole vault customer.
+   */
+  async detachPaymentMethod(config: GatewayConfig, paymentMethodId: string, customerId?: string): Promise<any> {
+    const params: Record<string, any> = customerId
+      ? { customer_vault: "delete_billing", customer_vault_id: customerId, billing_id: paymentMethodId }
+      : { customer_vault: "delete_customer", customer_vault_id: paymentMethodId };
+    const resp = await this.nmiPost(config, params);
+    if (!this.isApproved(resp)) {
+      console.error("KingdomFunding(NMI) detachPaymentMethod error:", { paymentMethodId, customerId, error: this.errorText(resp) });
+      throw new Error(this.errorText(resp) || "Failed to remove payment method");
+    }
+    return resp;
+  }
+
+  // ─── Read APIs (NMI Query API — returns XML) ──────────────
+  // NOTE: These power "view recurring donations" and "manage saved methods" screens.
+  // They hit NMI's Query API (query.php) which returns XML. Implemented with a light
+  // tag extractor; field coverage to be confirmed against the sandbox in BCAI-6.
 
   async getSubscription(config: GatewayConfig, subscriptionId: string): Promise<any> {
     try {
-      const baseUrl = this.getBaseUrl(config);
-      const response = await Axios.get(
-        `${baseUrl}/recurring-schedules/${subscriptionId}`,
-        this.axiosConfig(config)
-      );
-      return response.data || null;
+      const resp = await Axios.get(this.getQueryUrl(config), {
+        params: { security_key: config.privateKey, report_type: "recurring", subscription_id: subscriptionId },
+        timeout: 15000,
+      });
+      const subs = parseNmiSubscriptions(typeof resp.data === "string" ? resp.data : "");
+      return subs[0] || null;
     } catch (error: any) {
-      console.error("KingdomFunding getSubscription error:", error.response?.data || error.message);
+      console.error("KingdomFunding(NMI) getSubscription error:", error.message);
       return null;
     }
   }
 
   async getCustomerSubscriptions(config: GatewayConfig, customerId: string): Promise<any> {
     try {
-      const baseUrl = this.getBaseUrl(config);
-      // Accept Blue paginates (default ~10/page) and may ignore per_page. Walk pages
-      // until we get an empty batch OR a page returns no new IDs (param ignored case).
-      const all: any[] = [];
-      const seen = new Set<string>();
-      for (let page = 1; page <= 50; page++) {
-        const response = await Axios.get(
-          `${baseUrl}/customers/${customerId}/recurring-schedules`,
-          { ...this.axiosConfig(config), timeout: 15000, params: { page, per_page: 100 } }
-        );
-        const batch: any[] = Array.isArray(response.data) ? response.data : (response.data?.data || []);
-        if (batch.length === 0) break;
-        const fresh = batch.filter((s: any) => !seen.has(String(s.id)));
-        if (fresh.length === 0) break;
-        fresh.forEach((s: any) => seen.add(String(s.id)));
-        all.push(...fresh);
-      }
-      return all;
+      const resp = await Axios.get(this.getQueryUrl(config), {
+        params: { security_key: config.privateKey, report_type: "recurring", customer_vault_id: customerId },
+        timeout: 15000,
+      });
+      return parseNmiSubscriptions(typeof resp.data === "string" ? resp.data : "");
     } catch (error: any) {
-      console.error("KingdomFunding getCustomerSubscriptions error:", error.response?.data || error.message);
+      console.error("KingdomFunding(NMI) getCustomerSubscriptions error:", error.message);
       return [];
     }
   }
 
   async getCustomerPaymentMethods(config: GatewayConfig, customer: any): Promise<any> {
     try {
-      const baseUrl = this.getBaseUrl(config);
       const customerId = typeof customer === "string" ? customer : customer?.id || customer?.customerId;
       if (!customerId) return [];
-
-      const response = await Axios.get(
-        `${baseUrl}/customers/${customerId}/payment-methods`,
-        this.axiosConfig(config)
-      );
-      return response.data || [];
+      const resp = await Axios.get(this.getQueryUrl(config), {
+        params: { security_key: config.privateKey, report_type: "customer_vault", customer_vault_id: customerId },
+        timeout: 15000,
+      });
+      return parseNmiVaultMethods(typeof resp.data === "string" ? resp.data : "");
     } catch (error: any) {
-      console.error("KingdomFunding getCustomerPaymentMethods error:", error.response?.data || error.message);
+      console.error("KingdomFunding(NMI) getCustomerPaymentMethods error:", error.message);
       return [];
     }
   }
 
-  // ─── Payment Method Management ────────────────────────────
-
-  /**
-   * Save a payment method to a customer in KingdomFunding.
-   * For cards: POST /customers/:id/payment-methods — { card, expiry_month, expiry_year, name, avs_zip }
-   * For checks: POST /customers/:id/payment-methods — { routing_number, account_number, account_type, name }
-   * For source/nonce: POST /customers/:id/payment-methods — { source: "nonce-xxx" }
-   */
-  async attachPaymentMethod(config: GatewayConfig, paymentMethodId: string, options: any): Promise<any> {
-    try {
-      const baseUrl = this.getBaseUrl(config);
-      const customerId = options.customerId;
-      if (!customerId) throw new Error("customerId required to save payment method");
-
-      const payload: any = {};
-
-      // Accept Blue requires expiry_month / expiry_year as integers (not strings).
-      // Frontend tokenization returns them as strings — coerce here defensively.
-      const expMonth = options.expiry_month != null && options.expiry_month !== ""
-        ? Number(options.expiry_month) : undefined;
-      const expYear = options.expiry_year != null && options.expiry_year !== ""
-        ? Number(options.expiry_year) : undefined;
-
-      const pmIdStr = paymentMethodId ? String(paymentMethodId) : "";
-      if (options.source || pmIdStr.startsWith("nonce-") || pmIdStr.startsWith("ref-")) {
-        // Save from a nonce token or transaction reference
-        payload.source = options.source || pmIdStr;
-        // Only auto-prefix with nonce- if it's not already prefixed
-        if (!payload.source.startsWith("nonce-") && !payload.source.startsWith("ref-")) payload.source = `nonce-${payload.source}`;
-        if (expMonth != null && !Number.isNaN(expMonth)) payload.expiry_month = expMonth;
-        if (expYear != null && !Number.isNaN(expYear)) payload.expiry_year = expYear;
-      } else if (options.routing_number) {
-        // Save a check/ACH payment method
-        payload.routing_number = options.routing_number;
-        payload.account_number = options.account_number;
-        payload.account_type = options.account_type || "checking";
-        payload.name = options.name || "";
-        payload.sec_code = options.sec_code || "WEB";
-      } else {
-        // Save card data
-        payload.card = options.card;
-        if (expMonth != null && !Number.isNaN(expMonth)) payload.expiry_month = expMonth;
-        if (expYear != null && !Number.isNaN(expYear)) payload.expiry_year = expYear;
-        payload.name = options.name || "";
-        if (options.avs_zip) payload.avs_zip = options.avs_zip;
-      }
-
-      try {
-        const response = await Axios.post(
-          `${baseUrl}/customers/${customerId}/payment-methods`,
-          payload,
-          this.axiosConfig(config)
-        );
-        return response.data;
-      } catch (err: any) {
-        // Accept Blue rejects duplicate card adds with an Invalid state error and
-        // returns the EXISTING payment_method in error_details. Treat that as success
-        // and reuse the existing payment-method ID.
-        const errDetails = err.response?.data?.error_details;
-        const existing = errDetails?.payment_method;
-        if (existing?.id) {
-          return existing;
-        }
-        throw err;
-      }
-    } catch (error: any) {
-      console.error("KingdomFunding attachPaymentMethod error:", JSON.stringify(error.response?.data) || error.message);
-      throw new Error(error.response?.data?.error_message || error.message || "Failed to save payment method");
-    }
-  }
-
-  /**
-   * Remove a payment method from KingdomFunding.
-   * DELETE /payment-methods/:id
-   */
-  async detachPaymentMethod(config: GatewayConfig, paymentMethodId: string, customerId?: string): Promise<any> {
-    try {
-      const baseUrl = this.getBaseUrl(config);
-      const response = await Axios.delete(
-        `${baseUrl}/payment-methods/${paymentMethodId}`,
-        this.axiosConfig(config)
-      );
-      return response.data;
-    } catch (error: any) {
-      console.error("KingdomFunding detachPaymentMethod error:", error.response?.data || error.message, { paymentMethodId, customerId });
-      throw new Error(error.response?.data?.error_message || error.message || "Failed to remove payment method");
-    }
-  }
-
-  // ─── Event Logging ────────────────────────────────────────
+  // ─── Event & Donation Logging ─────────────────────────────
 
   async logEvent(churchId: string, event: any, eventData: any, repos: any): Promise<void> {
     try {
       const eventLog = new EventLog();
       eventLog.churchId = churchId;
-      eventLog.eventType = eventData?.eventType || event?.type || "unknown";
+      eventLog.eventType = eventData?.eventType || event?.event_type || "unknown";
       eventLog.provider = "kingdomfunding";
-      eventLog.providerId = eventData?.id?.toString() || event?.id?.toString() || "";
+      eventLog.providerId = eventData?.id?.toString() || event?.event_id?.toString() || "";
       eventLog.message = JSON.stringify(event);
       await repos.eventLog.save(eventLog);
     } catch (err) {
-      console.error("KingdomFunding logEvent error:", err);
+      console.error("KingdomFunding(NMI) logEvent error:", err);
     }
   }
 
   async logDonation(
-    config: GatewayConfig,
+    _config: GatewayConfig,
     churchId: string,
     eventData: any,
     repos: any,
-    status: "pending" | "complete" = "complete"
+    _status: "pending" | "complete" = "complete"
   ): Promise<any> {
     try {
-      // Extract amount — KingdomFunding uses auth_amount or amount_details.amount
-      let amount = eventData.auth_amount || eventData.amount || 0;
-      if (eventData.transaction?.amount_details?.amount) {
-        amount = eventData.transaction.amount_details.amount;
-      }
+      let amount = Number(eventData.auth_amount || eventData.amount || eventData.transaction?.amount || 0);
 
-      // Find person — from direct person data (charge flow) or from customer/transaction lookup (webhook flow)
+      // Find person — from direct person data (charge flow) or customer/txn lookup (webhook flow).
       let personId: string | undefined;
       if (eventData.person?.id) {
         personId = eventData.person.id;
       } else {
-        // Try customer_id from webhook body
-        const customerId = eventData.customer?.customer_id || eventData.transaction?.customer?.customer_id;
-        if (customerId) {
-          const customer = await repos.customer.load(churchId, String(customerId));
+        const customerVaultId = eventData.customer_vault_id || eventData.transaction?.customer_vault_id;
+        if (customerVaultId) {
+          const customer = await repos.customer.load(churchId, String(customerVaultId));
           if (customer) personId = customer.personId;
         }
-
-        // Fallback: look up by reference_number in existing donations (charge endpoint logs first)
         if (!personId) {
-          const refNum = eventData.reference_number || eventData.transaction?.id;
+          const refNum = eventData.reference_number || eventData.id || eventData.transaction?.transaction_id;
           if (refNum) {
-            const existingDonation = await repos.donation.loadByTransactionId(churchId, String(refNum));
-            if (existingDonation?.personId) personId = existingDonation.personId;
+            const existing = await repos.donation.loadByTransactionId(churchId, String(refNum));
+            if (existing?.personId) personId = existing.personId;
           }
         }
       }
 
-      // Determine payment method type
-      const isCheck = !!eventData.transaction?.check_details?.routing_number;
+      // Payment method type. Prefer an explicit paymentType ("bank") passed by the
+      // charge flow, since NMI's token-sale response doesn't echo bank details.
+      const isCheck =
+        eventData.paymentType === "bank" ||
+        eventData.type === "bank" ||
+        !!(eventData.check_account || eventData.transaction?.check_account || eventData.account_type);
       const method = isCheck ? "ACH" : "Card";
-      const methodDetails = isCheck
-        ? `Check ****${eventData.transaction?.check_details?.last4 || ""}`
-        : `${eventData.card_type || "Card"} ****${eventData.last_4 || ""}`;
+      const last4 = eventData.last_4 || eventData.cc_number?.slice(-4) || "";
+      const methodDetails = isCheck ? `Check ****${last4}` : `${eventData.card_type || "Card"} ****${last4}`;
 
       const batch: DonationBatch = await repos.donationBatch.getOrCreateCurrent(churchId);
+      const refNumber = String(eventData.reference_number || eventData.id || eventData.transaction?.transaction_id || "");
 
-      const refNumber = String(eventData.reference_number || eventData.transaction?.id || eventData.id || "");
-
-      // Use the actual transaction timestamp instead of "now" — webhooks may arrive much later
-      // (ACH webhooks can be days delayed). Falls back to now if no timestamp is provided.
       let donationDate: Date = new Date();
       const txTimestamp = eventData.transaction?.created_at || eventData.created_at || eventData.timestamp;
       if (txTimestamp) {
@@ -1013,7 +830,6 @@ export class KingdomFundingGatewayProvider extends AbstractExperimentalGatewayPr
 
       const savedDonation = await repos.donation.save(donation);
 
-      // Allocate funds: subscription funds, charge funds array, or single fund fallback
       const fundsArray = eventData.subscriptionFunds || eventData.funds || [];
       if (fundsArray.length > 0) {
         for (const fund of fundsArray) {
@@ -1026,19 +842,13 @@ export class KingdomFundingGatewayProvider extends AbstractExperimentalGatewayPr
           await repos.fundDonation.save(fundDonation);
         }
       } else if (eventData.fundId) {
-        // Single fund donation — use the total amount
-        const fundDonation: FundDonation = {
-          churchId,
-          donationId: savedDonation.id,
-          fundId: eventData.fundId,
-          amount,
-        };
+        const fundDonation: FundDonation = { churchId, donationId: savedDonation.id, fundId: eventData.fundId, amount };
         await repos.fundDonation.save(fundDonation);
       }
 
       return savedDonation;
     } catch (err) {
-      console.error("KingdomFunding logDonation error:", err);
+      console.error("KingdomFunding(NMI) logDonation error:", err);
       throw err;
     }
   }
@@ -1052,12 +862,70 @@ export class KingdomFundingGatewayProvider extends AbstractExperimentalGatewayPr
     try {
       const donation = await repos.donation.loadByTransactionId(churchId, transactionId);
       if (donation) {
-        // Update the donation status
-        // The method field can encode the status for now
         await repos.donation.save({ ...donation, notes: `${donation.notes || ""} [status: ${status}]` });
       }
     } catch (err) {
-      console.error("KingdomFunding updateDonationStatus error:", err);
+      console.error("KingdomFunding(NMI) updateDonationStatus error:", err);
     }
   }
+}
+
+// ─── Module-level helpers ───────────────────────────────────
+
+function safeJsonParse(s: string): any {
+  try { return JSON.parse(s); } catch { return {}; }
+}
+
+/** Heuristic: distinguish a Collect.js payment_token from a numeric saved-id. */
+function isLikelyToken(value: any): boolean {
+  if (!value) return false;
+  const s = String(value);
+  // Collect.js tokens are long alphanumeric strings with dashes; saved ids are short/numeric/UUID.
+  return s.length > 20 && /[A-Za-z]/.test(s) && /-/.test(s);
+}
+
+/**
+ * Minimal extractor for repeated <tag>value</tag> pairs from NMI Query API XML.
+ * Avoids adding an XML parser dependency for the few fields the UI needs.
+ * Field coverage to be confirmed against sandbox responses (BCAI-6).
+ */
+function extractAll(xml: string, blockTag: string): string[] {
+  const re = new RegExp(`<${blockTag}[\\s>][\\s\\S]*?</${blockTag}>`, "g");
+  return xml.match(re) || [];
+}
+function tag(xml: string, name: string): string {
+  const m = xml.match(new RegExp(`<${name}>([\\s\\S]*?)</${name}>`));
+  return m ? m[1].trim() : "";
+}
+
+function parseNmiSubscriptions(xml: string): any[] {
+  // NOTE: NMI Query API (query.php) XML tag names should be confirmed against a live
+  // subscription list during sandbox webhook/recurring testing; these are best-effort.
+  const freqFromTags = (block: string): string => {
+    const month = tag(block, "month_frequency");
+    const day = tag(block, "day_frequency");
+    if (month) return month === "3" ? "quarterly" : month === "6" ? "biannually" : month === "12" ? "annually" : month === "2" ? "bimonthly" : "monthly";
+    if (day) return day === "7" ? "weekly" : day === "14" ? "biweekly" : day === "1" ? "daily" : "monthly";
+    return "monthly";
+  };
+  return extractAll(xml, "subscription").map((block) => ({
+    id: tag(block, "subscription_id"),
+    amount: tag(block, "plan_amount") || tag(block, "amount"),
+    nextRunDate: tag(block, "next_charge_date"),
+    status: tag(block, "subscription_status") || "active",
+    frequency: freqFromTags(block),
+    customer_vault_id: tag(block, "customer_vault_id"),
+    raw: block,
+  }));
+}
+
+function parseNmiVaultMethods(xml: string): any[] {
+  return extractAll(xml, "billing").map((block) => ({
+    id: tag(block, "billing_id"),
+    last4: (tag(block, "cc_number") || tag(block, "check_account")).slice(-4),
+    cardType: tag(block, "cc_type"),
+    expiry: tag(block, "cc_exp"),
+    type: tag(block, "account_type") ? "ach" : "card",
+    raw: block,
+  }));
 }

--- a/src/shared/helpers/gateways/KingdomFundingGatewayProvider.ts
+++ b/src/shared/helpers/gateways/KingdomFundingGatewayProvider.ts
@@ -1,0 +1,1027 @@
+import express from "express";
+import crypto from "crypto";
+import { AbstractExperimentalGatewayProvider } from "./AbstractExperimentalGatewayProvider.js";
+import { GatewayConfig, WebhookResult, ChargeResult, SubscriptionResult } from "./IGatewayProvider.js";
+import Axios from "axios";
+import { Environment } from "../Environment.js";
+import { Donation, DonationBatch, EventLog, FundDonation } from "../../../modules/giving/models/index.js";
+
+/**
+ * KingdomFunding payment gateway provider.
+ *
+ * Supports:
+ * - One-time card charges (via hosted tokenization nonce)
+ * - One-time ACH/check charges
+ * - Recurring schedules (single-step, not plan+subscription)
+ * - Customers with reusable saved payment methods
+ * - Refunds (full + partial)
+ * - Webhooks with HMAC-SHA256 signature verification
+ *
+ * DB column mapping:
+ *   gateways.publicKey    = Tokenization Key (pk_...)
+ *   gateways.privateKey   = API Source Key (encrypted)
+ *   gateways.webhookKey   = Webhook signature secret (encrypted)
+ *   gateways.settings     = { webhookId?, merchantId? }
+ *
+ * Auth: HTTP Basic — Authorization: Basic base64(sourceKey:pin)
+ * PIN is optional for sandbox, required for production CC refunds.
+ * We store the sourceKey in privateKey. PIN (if any) is in settings.pin.
+ */
+export class KingdomFundingGatewayProvider extends AbstractExperimentalGatewayProvider {
+  readonly name = "kingdomfunding";
+
+  async createProduct(_config: GatewayConfig, _churchId: string): Promise<string> {
+    return "";
+  }
+
+  // ─── Helpers ──────────────────────────────────────────────
+
+  private getBaseUrl(config: GatewayConfig): string {
+    const key = config.privateKey || "";
+    // Sandbox uses develop subdomain; production uses main API domain
+    const isDev = config.environment === "sandbox"
+      || (config.settings as any)?.sandbox === true
+      || key.includes("sandbox") || key.includes("test") || key.includes("develop");
+    return isDev
+      ? "https://api.develop.accept.blue/api/v2"
+      : "https://api.accept.blue/api/v2";
+  }
+
+  private getAuthHeader(config: GatewayConfig): string {
+    const sourceKey = config.privateKey || "";
+    const pin = (config.settings as any)?.pin || "";
+    return "Basic " + Buffer.from(`${sourceKey}:${pin}`).toString("base64");
+  }
+
+  private axiosConfig(config: GatewayConfig) {
+    return {
+      headers: {
+        "Authorization": this.getAuthHeader(config),
+        "Content-Type": "application/json"
+      }
+    };
+  }
+
+  // ─── Webhook Management ───────────────────────────────────
+
+  /**
+   * Webhooks are configured in the Control Panel, not via API.
+   * The API docs show webhook CRUD but we'll handle setup in the admin UI.
+   * This method is a no-op placeholder; ensureWebhookExists() is the real entry point.
+   */
+  async createWebhookEndpoint(config: GatewayConfig, webhookUrl: string): Promise<{ id: string; secret?: string }> {
+    // KingdomFunding webhook creation is done via the Control Panel
+    // Return empty — the admin should set this up manually or via ensureWebhookExists
+    console.log("KingdomFunding: createWebhookEndpoint called (webhooks configured via Control Panel)", { webhookUrl });
+    return { id: "", secret: "" };
+  }
+
+  async deleteWebhooksByChurchId(_config: GatewayConfig, _churchId: string): Promise<void> {
+    // No-op: webhooks managed via Control Panel
+  }
+
+  /**
+   * Verify KingdomFunding webhook signature using HMAC-SHA256.
+   *
+   * The gateway sends an `X-Signature` header containing the HMAC-SHA256 hash
+   * of the raw request body, using the webhook endpoint's signature key as the secret.
+   *
+   * Webhook event types:
+   *   Transaction: succeeded, updated, declined, error, status
+   *   Batch: closed
+   */
+  async verifyWebhookSignature(
+    config: GatewayConfig,
+    headers: express.Request["headers"],
+    body: any
+  ): Promise<WebhookResult> {
+    const signatureHeader = (headers["x-signature"] || "") as string;
+    const webhookSecret = config.webhookKey;
+
+    // No webhook secret configured at all — refuse to process (do not silently accept).
+    // This forces churches to configure the webhook secret in B1Admin before
+    // their Kingdom Funding webhooks can be processed.
+    if (!webhookSecret) {
+      console.error("KingdomFunding webhook: no webhook secret configured for this church; rejecting.");
+      return { success: false, shouldProcess: false };
+    }
+
+    // Secret is configured — signature is REQUIRED on every incoming webhook.
+    if (!signatureHeader) {
+      console.error("KingdomFunding webhook: missing X-Signature header; rejecting.");
+      return { success: false, shouldProcess: false };
+    }
+
+    // Verify HMAC-SHA256 signature
+    const rawBody = typeof body === "string" ? body : JSON.stringify(body);
+    const expectedSignature = crypto
+      .createHmac("sha256", webhookSecret)
+      .update(rawBody, "utf-8")
+      .digest("hex");
+
+    let signatureMatches = false;
+    try {
+      // timingSafeEqual throws if buffers differ in length — guard with try/catch
+      // so an attacker can't probe length via exception behavior.
+      signatureMatches = crypto.timingSafeEqual(
+        Buffer.from(signatureHeader, "hex"),
+        Buffer.from(expectedSignature, "hex")
+      );
+    } catch {
+      signatureMatches = false;
+    }
+
+    if (!signatureMatches) {
+      console.error("KingdomFunding webhook: Signature mismatch");
+      return { success: false, shouldProcess: false };
+    }
+
+    // Parse the event payload
+    // KingdomFunding webhook schema: { type, subType, event, id, timestamp, data }
+    const eventType = body.type || "";          // "succeeded", "declined", "error", "status", "updated", "closed"
+    const eventSubType = body.subType || "";    // "charge", "credit", "refund", "adjust", "void", "settled", etc.
+    const eventCategory = body.event || "";     // "transaction" or "batch"
+    const eventId = body.id || "";
+    const eventData = body.data || {};
+
+    // Determine if we should process this as a donation
+    const isTransactionEvent = eventCategory === "transaction";
+    const shouldProcess = isTransactionEvent && (
+      eventType === "succeeded" ||
+      eventType === "status"    // ACH status updates (settled, returned, etc.)
+    );
+
+    return {
+      success: true,
+      shouldProcess,
+      eventType: `${eventType}.${eventSubType}`,  // e.g. "succeeded.charge", "status.settled"
+      eventId,
+      eventData: {
+        ...eventData,
+        id: eventData.reference_number || eventData.transaction?.id || eventId,
+        eventType: `${eventType}.${eventSubType}`,
+        eventCategory,
+        // Preserve original fields for downstream processing
+        status: eventData.status,
+        status_code: eventData.status_code,
+        auth_amount: eventData.auth_amount,
+        card_type: eventData.card_type,
+        last_4: eventData.last_4,
+      },
+    };
+  }
+
+  // ─── Payment Processing ───────────────────────────────────
+
+  /**
+   * Process a one-time charge via KingdomFunding.
+   *
+   * Card charges use: source = "nonce-{token}" from hosted tokenization
+   * Saved payment method charges use: source = "pm-{paymentMethodId}"
+   * Check/ACH charges route to processBankCharge()
+   */
+  async processCharge(config: GatewayConfig, donationData: any): Promise<ChargeResult> {
+    if (donationData.type === "bank" || donationData.paymentType === "bank") {
+      return this.processBankCharge(config, donationData);
+    }
+
+    try {
+      const baseUrl = this.getBaseUrl(config);
+
+      // Determine the source: nonce token, saved payment method, or raw card token
+      let source = "";
+      if (donationData.paymentMethodId) {
+        source = `pm-${donationData.paymentMethodId}`;
+      } else if (donationData.token || donationData.id) {
+        const token = donationData.token || donationData.id;
+        source = token.startsWith("nonce-") ? token : `nonce-${token}`;
+      }
+
+      if (!source) {
+        return { success: false, transactionId: "", data: { error: "Missing payment token or payment method" } };
+      }
+
+      const payload: any = {
+        amount: donationData.amount,
+        source,
+        name: donationData.name || donationData.person?.name || "",
+      };
+
+      // Add expiry data if provided (required for nonce charges)
+      // Normalize: expiry_month as integer 1-12, expiry_year as 4-digit integer
+      if (donationData.expiry_month) payload.expiry_month = Number(donationData.expiry_month);
+      if (donationData.expiry_year) {
+        let ey = Number(donationData.expiry_year);
+        if (ey > 0 && ey < 100) ey += 2000;
+        payload.expiry_year = ey;
+      }
+      if (donationData.avs_zip) payload.avs_zip = donationData.avs_zip;
+
+      // Add billing info if available
+      if (donationData.billing_info || donationData.person) {
+        const person = donationData.person || {};
+        payload.billing_info = donationData.billing_info || {
+          first_name: person.firstName || person.first_name || "",
+          last_name: person.lastName || person.last_name || "",
+          email: person.email || "",
+        };
+      }
+
+      // Add customer reference if available (Accept Blue expects numeric customer_id)
+      if (donationData.customerId) {
+        const cid = Number(donationData.customerId);
+        payload.customer_id = isNaN(cid) ? donationData.customerId : cid;
+      }
+
+      const response = await Axios.post(
+        `${baseUrl}/transactions/charge`,
+        payload,
+        this.axiosConfig(config)
+      );
+
+      const result = response.data;
+
+      if (result.status === "Approved" || result.status_code === "A") {
+        return {
+          success: true,
+          transactionId: String(result.reference_number || result.transaction?.id || ""),
+          data: {
+            ...result,
+            status: "active",
+            reference_number: result.reference_number,
+            auth_amount: result.auth_amount,
+            card_type: result.card_type,
+            last_4: result.last_4,
+          }
+        };
+      }
+
+      return {
+        success: false,
+        transactionId: "",
+        data: { error: result.error_message || result.error_details || "Charge declined", ...result }
+      };
+    } catch (error: any) {
+      const errData = error.response?.data || {};
+      const status = error.response?.status;
+      // Accept Blue sometimes returns HTML error pages (e.g. nginx 500/502/503)
+      const isHtmlError = typeof errData === "string" && errData.includes("<html");
+      const errorMsg = isHtmlError
+        ? `Accept Blue server error (HTTP ${status}). Please try again.`
+        : (errData.error_message || errData.error_details || error.message || "Charge failed");
+      console.error("KingdomFunding processCharge error:", JSON.stringify({ status, isHtmlError, message: errorMsg }));
+      return {
+        success: false,
+        transactionId: "",
+        data: { error: errorMsg }
+      };
+    }
+  }
+
+  /**
+   * Process a bank/ACH charge.
+   * KingdomFunding handles check charges on the same /transactions/charge endpoint
+   * with routing_number, account_number, account_type, sec_code fields.
+   *
+   * When using a saved check payment method, use source = "pm-{id}".
+   * For tokenized bank data, the frontend should provide routing/account details
+   * or a nonce token.
+   */
+  private async processBankCharge(config: GatewayConfig, donationData: any): Promise<ChargeResult> {
+    try {
+      const baseUrl = this.getBaseUrl(config);
+
+      const payload: any = {
+        amount: donationData.amount,
+        name: donationData.name || donationData.person?.name || "",
+      };
+
+      if (donationData.paymentMethodId) {
+        // Charge a saved check payment method
+        payload.source = `pm-${donationData.paymentMethodId}`;
+      } else if (donationData.token || donationData.id) {
+        // Tokenized bank data
+        const token = donationData.token || donationData.id;
+        payload.source = token.startsWith("nonce-") ? token : `nonce-${token}`;
+      } else if (donationData.routing_number && donationData.account_number) {
+        // Raw bank fields
+        payload.routing_number = donationData.routing_number;
+        payload.account_number = donationData.account_number;
+        payload.account_type = donationData.account_type || "checking";
+        payload.sec_code = donationData.sec_code || "WEB";
+      } else {
+        return { success: false, transactionId: "", data: { error: "Missing bank payment data" } };
+      }
+
+      if (donationData.customerId) {
+        payload.customer_id = donationData.customerId;
+      }
+
+      const response = await Axios.post(
+        `${baseUrl}/transactions/charge`,
+        payload,
+        this.axiosConfig(config)
+      );
+
+      const result = response.data;
+
+      if (result.status === "Approved" || result.status_code === "A") {
+        return {
+          success: true,
+          transactionId: String(result.reference_number || result.transaction?.id || ""),
+          data: {
+            ...result,
+            status: "active",
+            reference_number: result.reference_number,
+            auth_amount: result.auth_amount,
+          }
+        };
+      }
+
+      return {
+        success: false,
+        transactionId: "",
+        data: { error: result.error_message || result.error_details || "ACH charge declined", ...result }
+      };
+    } catch (error: any) {
+      const errData = error.response?.data || {};
+      console.error("KingdomFunding processBankCharge error:", errData.error_message || error.message);
+      return {
+        success: false,
+        transactionId: "",
+        data: { error: errData.error_message || errData.error_details || error.message || "ACH charge failed" }
+      };
+    }
+  }
+
+  // ─── Recurring Schedules ──────────────────────────────────
+
+  /**
+   * Map our frontend interval format to KingdomFunding frequency strings.
+   * KingdomFunding supports: daily, weekly, biweekly, monthly, bimonthly, quarterly, biannually, annually
+   */
+  private mapIntervalToFrequency(interval: any): string {
+    if (!interval) return "monthly";
+
+    // Handle string format directly
+    const str = typeof interval === "string" ? interval : interval.interval || interval.frequency || "";
+    const lower = str.toLowerCase();
+
+    const map: Record<string, string> = {
+      "one_week": "weekly",
+      "two_week": "biweekly",
+      "one_month": "monthly",
+      "two_month": "bimonthly",
+      "three_month": "quarterly",
+      "six_month": "biannually",
+      "one_year": "annually",
+      // Direct KingdomFunding values pass through
+      "daily": "daily",
+      "weekly": "weekly",
+      "biweekly": "biweekly",
+      "monthly": "monthly",
+      "bimonthly": "bimonthly",
+      "quarterly": "quarterly",
+      "biannually": "biannually",
+      "annually": "annually",
+      // Uppercase format fallback
+      "DAILY": "daily",
+      "WEEKLY": "weekly",
+      "MONTHLY": "monthly",
+      "QUARTERLY": "quarterly",
+      "ANNUAL": "annually",
+    };
+
+    return map[lower] || map[str] || "monthly";
+  }
+
+  /**
+   * Create a recurring schedule in KingdomFunding.
+   *
+   * KingdomFunding uses a single-step model: POST /customers/:id/recurring-schedules
+   * Required: title, amount, payment_method_id, frequency, next_run_date
+   *
+   * The customer and payment method must exist before creating a schedule.
+   * If no customerId is provided, we'll create one first.
+   */
+  async createSubscription(config: GatewayConfig, subscriptionData: any): Promise<SubscriptionResult> {
+    try {
+      const baseUrl = this.getBaseUrl(config);
+      const name = subscriptionData.name || subscriptionData.person?.name?.display || subscriptionData.person?.name || "Donor";
+      const email = subscriptionData.email || subscriptionData.person?.email || "";
+      const token = subscriptionData.token || subscriptionData.id;
+      // Only treat as nonce if it's not a numeric saved-PM ID
+      const isSavedPmId = token && /^\d+$/.test(String(token));
+      const nonceSource = (!isSavedPmId && token) ? (String(token).startsWith("nonce-") ? String(token) : `nonce-${token}`) : "";
+
+      // Normalize expiry year to 4-digit (accept.blue requires 2020-9999)
+      let expiryYear = subscriptionData.expiry_year ? Number(subscriptionData.expiry_year) : undefined;
+      if (expiryYear && expiryYear < 100) expiryYear += 2000;
+      const expiryMonth = subscriptionData.expiry_month ? Number(subscriptionData.expiry_month) : undefined;
+
+      // Step 1: Determine if the recurring donation starts today
+      let startsToday = false;
+      if (subscriptionData.billing_cycle_anchor) {
+        let anchorMs = subscriptionData.billing_cycle_anchor;
+        if (anchorMs < 10000000000) anchorMs = anchorMs * 1000;
+        const anchorDate = new Date(anchorMs);
+        const today = new Date();
+        startsToday = anchorDate.toISOString().split("T")[0] === today.toISOString().split("T")[0]
+          || anchorDate <= today;
+      } else {
+        startsToday = true; // No anchor = starts now
+      }
+
+      let customerId = subscriptionData.customerId;
+      let referenceNumber: number | null = null;
+
+      // Detect ACH/bank flow
+      const isBank = subscriptionData.type === "bank"
+        || (subscriptionData.routing_number && subscriptionData.account_number);
+
+      // Step 2: If starts today, charge immediately first
+      if (startsToday && (nonceSource || isBank)) {
+        const chargePayload: any = {
+          amount: subscriptionData.amount,
+          name,
+        };
+
+        if (isBank) {
+          chargePayload.routing_number = subscriptionData.routing_number;
+          chargePayload.account_number = subscriptionData.account_number;
+          chargePayload.account_type = subscriptionData.account_type || "checking";
+          chargePayload.sec_code = subscriptionData.sec_code || "WEB";
+        } else {
+          chargePayload.source = nonceSource;
+          if (expiryMonth) chargePayload.expiry_month = expiryMonth;
+          if (expiryYear) chargePayload.expiry_year = expiryYear;
+        }
+
+        const chargeResponse = await Axios.post(
+          `${baseUrl}/transactions/charge`,
+          chargePayload,
+          this.axiosConfig(config)
+        );
+
+        referenceNumber = chargeResponse.data?.reference_number;
+        if (!referenceNumber) {
+          const errMsg = chargeResponse.data?.error_message || "Initial charge failed";
+          console.error("KingdomFunding: Initial recurring charge failed", chargeResponse.data);
+          return { success: false, subscriptionId: "", data: { error: errMsg } };
+        }
+      }
+
+      // Step 3: Create customer
+      if (!customerId) {
+        customerId = await this.createCustomer(config, email, name);
+      }
+
+      // Step 4: Create payment method on the customer
+      let paymentMethodId = subscriptionData.paymentMethodId;
+
+      // If the incoming id is a numeric Accept Blue PM ID (saved card), use it directly
+      const rawId = subscriptionData.id ? String(subscriptionData.id) : "";
+      if (!paymentMethodId && rawId && /^\d+$/.test(rawId) && !rawId.startsWith("nonce-")) {
+        paymentMethodId = Number(rawId);
+      }
+
+      if (!paymentMethodId) {
+        const pmPayload: any = {};
+
+        if (referenceNumber) {
+          // Create payment method from the transaction reference (works for both card and ACH)
+          pmPayload.source = `ref-${referenceNumber}`;
+          if (!isBank && expiryMonth) pmPayload.expiry_month = expiryMonth;
+          if (!isBank && expiryYear) pmPayload.expiry_year = expiryYear;
+        } else if (isBank) {
+          // ACH future-dated subscription — create PM directly from routing/account
+          pmPayload.routing_number = subscriptionData.routing_number;
+          pmPayload.account_number = subscriptionData.account_number;
+          pmPayload.account_type = subscriptionData.account_type || "checking";
+        } else if (nonceSource) {
+          // Create payment method from the nonce
+          pmPayload.source = nonceSource;
+          if (expiryMonth) pmPayload.expiry_month = expiryMonth;
+          if (expiryYear) pmPayload.expiry_year = expiryYear;
+        }
+
+        if (name) pmPayload.name = name;
+
+        try {
+          const pmResponse = await Axios.post(
+            `${baseUrl}/customers/${customerId}/payment-methods`,
+            pmPayload,
+            this.axiosConfig(config)
+          );
+          paymentMethodId = pmResponse.data?.id;
+        } catch (pmErr: any) {
+          // If the payment method already exists for this customer, reuse it
+          const existingPm = pmErr.response?.data?.error_details?.payment_method;
+          if (existingPm?.id) {
+            console.log("KingdomFunding: Payment method already exists, reusing", { pmId: existingPm.id });
+            paymentMethodId = existingPm.id;
+          } else {
+            console.error("KingdomFunding: Failed to create payment method", pmErr.response?.data || pmErr.message);
+            return { success: false, subscriptionId: "", data: { error: "Failed to save payment method for recurring donation" } };
+          }
+        }
+
+        if (!paymentMethodId) {
+          console.error("KingdomFunding: No payment method ID obtained");
+          return { success: false, subscriptionId: "", data: { error: "Failed to save payment method for recurring donation" } };
+        }
+      }
+
+      // Step 5: Calculate next_run_date for the schedule
+      // If we already charged today, next run should be the next cycle date
+      const frequency = this.mapIntervalToFrequency(subscriptionData.interval);
+      let nextRunDate: string;
+
+      if (startsToday) {
+        // Already charged today, schedule starts on the next cycle
+        const next = new Date();
+        switch (frequency) {
+          case "daily": next.setDate(next.getDate() + 1); break;
+          case "weekly": next.setDate(next.getDate() + 7); break;
+          case "biweekly": next.setDate(next.getDate() + 14); break;
+          case "monthly": next.setMonth(next.getMonth() + 1); break;
+          case "bimonthly": next.setMonth(next.getMonth() + 2); break;
+          case "quarterly": next.setMonth(next.getMonth() + 3); break;
+          case "biannually": next.setMonth(next.getMonth() + 6); break;
+          case "annually": next.setFullYear(next.getFullYear() + 1); break;
+          default: next.setMonth(next.getMonth() + 1); break;
+        }
+        nextRunDate = next.toISOString().split("T")[0];
+      } else {
+        // Starts in the future
+        let anchorMs = subscriptionData.billing_cycle_anchor;
+        if (anchorMs < 10000000000) anchorMs = anchorMs * 1000;
+        nextRunDate = new Date(anchorMs).toISOString().split("T")[0];
+      }
+
+      // Step 6: Create the recurring schedule
+      const schedulePayload = {
+        title: `Recurring Donation $${subscriptionData.amount}`,
+        amount: subscriptionData.amount,
+        payment_method_id: paymentMethodId,
+        frequency,
+        next_run_date: nextRunDate,
+        num_left: 0,  // 0 = ongoing
+        active: true,
+      };
+
+      const response = await Axios.post(
+        `${baseUrl}/customers/${customerId}/recurring-schedules`,
+        schedulePayload,
+        this.axiosConfig(config)
+      );
+
+      const schedule = response.data;
+      const scheduleId = String(schedule.id || "");
+
+      if (!scheduleId) {
+        console.error("KingdomFunding: Recurring schedule created but no ID returned", schedule);
+        return { success: false, subscriptionId: "", data: { error: "Recurring schedule creation failed" } };
+      }
+
+      return {
+        success: true,
+        subscriptionId: scheduleId,
+        data: {
+          ...schedule,
+          status: "active",
+          customerId: String(customerId),
+          paymentMethodId: String(paymentMethodId),
+          frequency,
+          nextRunDate,
+          initialChargeRef: referenceNumber ? String(referenceNumber) : undefined,
+        }
+      };
+    } catch (error: any) {
+      const errData = error.response?.data || {};
+      console.error("KingdomFunding createSubscription error:", errData.error_message || errData.message || error.message);
+      if (error.response?.data) console.error("KingdomFunding createSubscription response data:", JSON.stringify(error.response.data));
+      return {
+        success: false,
+        subscriptionId: "",
+        data: { error: errData.error_message || errData.message || error.message || "Subscription creation failed" }
+      };
+    }
+  }
+
+  async updateSubscription(config: GatewayConfig, subscriptionData: any): Promise<SubscriptionResult> {
+    try {
+      const baseUrl = this.getBaseUrl(config);
+      const scheduleId = subscriptionData.subscriptionId || subscriptionData.id;
+
+      if (!scheduleId) {
+        return { success: false, subscriptionId: "", data: { error: "Missing recurring schedule ID" } };
+      }
+
+      const updatePayload: any = {};
+      if (subscriptionData.amount) updatePayload.amount = subscriptionData.amount;
+      if (subscriptionData.interval) updatePayload.frequency = this.mapIntervalToFrequency(subscriptionData.interval);
+      if (subscriptionData.next_run_date) updatePayload.next_run_date = subscriptionData.next_run_date;
+      if (subscriptionData.active !== undefined) updatePayload.active = subscriptionData.active;
+      if (subscriptionData.paymentMethodId) updatePayload.payment_method_id = subscriptionData.paymentMethodId;
+
+      const response = await Axios.patch(
+        `${baseUrl}/recurring-schedules/${scheduleId}`,
+        updatePayload,
+        this.axiosConfig(config)
+      );
+
+      return {
+        success: true,
+        subscriptionId: String(scheduleId),
+        data: response.data
+      };
+    } catch (error: any) {
+      const errData = error.response?.data || {};
+      console.error("KingdomFunding updateSubscription error:", errData.error_message || error.message);
+      return {
+        success: false,
+        subscriptionId: subscriptionData.subscriptionId || "",
+        data: { error: errData.error_message || error.message || "Subscription update failed" }
+      };
+    }
+  }
+
+  async cancelSubscription(config: GatewayConfig, subscriptionId: string, _reason?: string): Promise<void> {
+    try {
+      const baseUrl = this.getBaseUrl(config);
+      console.log("KingdomFunding cancelSubscription: deactivating schedule", { subscriptionId, url: `${baseUrl}/recurring-schedules/${subscriptionId}` });
+
+      // Deactivate by setting active: false
+      const response = await Axios.patch(
+        `${baseUrl}/recurring-schedules/${subscriptionId}`,
+        { active: false },
+        this.axiosConfig(config)
+      );
+
+      console.log("KingdomFunding: Recurring schedule deactivated", { subscriptionId, responseData: response.data });
+    } catch (error: any) {
+      console.error("KingdomFunding cancelSubscription error:", {
+        subscriptionId,
+        status: error.response?.status,
+        data: error.response?.data,
+        message: error.message
+      });
+      throw new Error(error.response?.data?.error_message || error.message || "Failed to cancel subscription");
+    }
+  }
+
+  // ─── Refunds ──────────────────────────────────────────────
+
+  /**
+   * Refund a previously settled transaction.
+   * POST /transactions/refund — body: { reference_number, amount? }
+   * Omit amount for full refund.
+   */
+  async processRefund(config: GatewayConfig, refundData: any): Promise<ChargeResult> {
+    try {
+      const baseUrl = this.getBaseUrl(config);
+
+      const payload: any = {
+        reference_number: parseInt(refundData.reference_number || refundData.transactionId, 10),
+      };
+
+      // If amount provided, partial refund; otherwise full refund
+      if (refundData.amount) {
+        payload.amount = refundData.amount;
+      }
+
+      const response = await Axios.post(
+        `${baseUrl}/transactions/refund`,
+        payload,
+        this.axiosConfig(config)
+      );
+
+      const result = response.data;
+
+      if (result.status === "Approved" || result.status_code === "A") {
+        return {
+          success: true,
+          transactionId: String(result.reference_number || ""),
+          data: result
+        };
+      }
+
+      return {
+        success: false,
+        transactionId: "",
+        data: { error: result.error_message || "Refund failed", ...result }
+      };
+    } catch (error: any) {
+      const errData = error.response?.data || {};
+      console.error("KingdomFunding processRefund error:", errData.error_message || error.message);
+      return {
+        success: false,
+        transactionId: "",
+        data: { error: errData.error_message || error.message || "Refund failed" }
+      };
+    }
+  }
+
+  // ─── Fee Calculation ──────────────────────────────────────
+
+  /**
+   * Calculate transaction fees using KF-specific settings (flatRateKF / transFeeKF).
+   * Fee calculation is our own logic, not provider-dependent.
+   */
+  async calculateFees(amount: number, churchId: string, _currency?: string): Promise<number> {
+    let customFixedFee: number | null = null;
+    let customPercentFee: number | null = null;
+
+    if (churchId) {
+      try {
+        const response = await Axios.get(Environment.membershipApi + "/settings/public/" + churchId);
+        const data = response.data;
+        if (data?.flatRateKF !== null && data?.flatRateKF !== undefined && data?.flatRateKF !== "") customFixedFee = +data.flatRateKF;
+        if (data?.transFeeKF !== null && data?.transFeeKF !== undefined && data?.transFeeKF !== "") customPercentFee = +data.transFeeKF / 100;
+      } catch (err) {
+        console.warn("KingdomFunding: Failed to load fee settings, using defaults", err);
+      }
+    }
+
+    const fixedFee = customFixedFee ?? 0.3;
+    const percentFee = customPercentFee ?? 0.029;
+    return Math.round(((amount + fixedFee) / (1 - percentFee) - amount) * 100) / 100;
+  }
+
+  // ─── Customer Management ──────────────────────────────────
+
+  /**
+   * Create a customer in KingdomFunding.
+   * POST /customers — body: { identifier, email, first_name, last_name, ... }
+   * Returns the customer ID (integer).
+   */
+  async createCustomer(config: GatewayConfig, email: string, name: string): Promise<string> {
+    try {
+      const baseUrl = this.getBaseUrl(config);
+      const nameParts = (name || "").split(" ");
+      const firstName = nameParts[0] || "";
+      const lastName = nameParts.slice(1).join(" ") || "";
+
+      const payload = {
+        identifier: email || name || "donor",
+        email: email || undefined,
+        first_name: firstName || undefined,
+        last_name: lastName || undefined,
+      };
+
+      const response = await Axios.post(
+        `${baseUrl}/customers`,
+        payload,
+        this.axiosConfig(config)
+      );
+
+      const customerId = response.data?.id;
+      if (!customerId) {
+        throw new Error("Customer creation returned no ID");
+      }
+
+      return String(customerId);
+    } catch (error: any) {
+      console.error("KingdomFunding createCustomer error:", error.response?.data || error.message);
+      throw new Error(error.response?.data?.error_message || error.message || "Failed to create customer");
+    }
+  }
+
+  async getCustomerSubscriptions(config: GatewayConfig, customerId: string): Promise<any> {
+    try {
+      const baseUrl = this.getBaseUrl(config);
+      const response = await Axios.get(
+        `${baseUrl}/customers/${customerId}/recurring-schedules`,
+        { ...this.axiosConfig(config), timeout: 15000 }
+      );
+      return response.data || [];
+    } catch (error: any) {
+      console.error("KingdomFunding getCustomerSubscriptions error:", error.response?.data || error.message);
+      return [];
+    }
+  }
+
+  async getCustomerPaymentMethods(config: GatewayConfig, customer: any): Promise<any> {
+    try {
+      const baseUrl = this.getBaseUrl(config);
+      const customerId = typeof customer === "string" ? customer : customer?.id || customer?.customerId;
+      if (!customerId) return [];
+
+      const response = await Axios.get(
+        `${baseUrl}/customers/${customerId}/payment-methods`,
+        this.axiosConfig(config)
+      );
+      return response.data || [];
+    } catch (error: any) {
+      console.error("KingdomFunding getCustomerPaymentMethods error:", error.response?.data || error.message);
+      return [];
+    }
+  }
+
+  // ─── Payment Method Management ────────────────────────────
+
+  /**
+   * Save a payment method to a customer in KingdomFunding.
+   * For cards: POST /customers/:id/payment-methods — { card, expiry_month, expiry_year, name, avs_zip }
+   * For checks: POST /customers/:id/payment-methods — { routing_number, account_number, account_type, name }
+   * For source/nonce: POST /customers/:id/payment-methods — { source: "nonce-xxx" }
+   */
+  async attachPaymentMethod(config: GatewayConfig, paymentMethodId: string, options: any): Promise<any> {
+    try {
+      const baseUrl = this.getBaseUrl(config);
+      const customerId = options.customerId;
+      if (!customerId) throw new Error("customerId required to save payment method");
+
+      const payload: any = {};
+
+      const pmIdStr = paymentMethodId ? String(paymentMethodId) : "";
+      if (options.source || pmIdStr.startsWith("nonce-") || pmIdStr.startsWith("ref-")) {
+        // Save from a nonce token or transaction reference
+        payload.source = options.source || pmIdStr;
+        // Only auto-prefix with nonce- if it's not already prefixed
+        if (!payload.source.startsWith("nonce-") && !payload.source.startsWith("ref-")) payload.source = `nonce-${payload.source}`;
+        if (options.expiry_month) payload.expiry_month = options.expiry_month;
+        if (options.expiry_year) payload.expiry_year = options.expiry_year;
+      } else if (options.routing_number) {
+        // Save a check/ACH payment method
+        payload.routing_number = options.routing_number;
+        payload.account_number = options.account_number;
+        payload.account_type = options.account_type || "checking";
+        payload.name = options.name || "";
+        payload.sec_code = options.sec_code || "WEB";
+      } else {
+        // Save card data
+        payload.card = options.card;
+        payload.expiry_month = options.expiry_month;
+        payload.expiry_year = options.expiry_year;
+        payload.name = options.name || "";
+        if (options.avs_zip) payload.avs_zip = options.avs_zip;
+      }
+
+      const response = await Axios.post(
+        `${baseUrl}/customers/${customerId}/payment-methods`,
+        payload,
+        this.axiosConfig(config)
+      );
+
+      return response.data;
+    } catch (error: any) {
+      console.error("KingdomFunding attachPaymentMethod error:", JSON.stringify(error.response?.data) || error.message);
+      throw new Error(error.response?.data?.error_message || error.message || "Failed to save payment method");
+    }
+  }
+
+  /**
+   * Remove a payment method from KingdomFunding.
+   * DELETE /payment-methods/:id
+   */
+  async detachPaymentMethod(config: GatewayConfig, paymentMethodId: string, customerId?: string): Promise<any> {
+    try {
+      const baseUrl = this.getBaseUrl(config);
+      console.log("KingdomFunding detachPaymentMethod:", { paymentMethodId, customerId });
+      const response = await Axios.delete(
+        `${baseUrl}/payment-methods/${paymentMethodId}`,
+        this.axiosConfig(config)
+      );
+      return response.data;
+    } catch (error: any) {
+      console.error("KingdomFunding detachPaymentMethod error:", error.response?.data || error.message, { paymentMethodId, customerId });
+      throw new Error(error.response?.data?.error_message || error.message || "Failed to remove payment method");
+    }
+  }
+
+  // ─── Event Logging ────────────────────────────────────────
+
+  async logEvent(churchId: string, event: any, eventData: any, repos: any): Promise<void> {
+    try {
+      const eventLog = new EventLog();
+      eventLog.churchId = churchId;
+      eventLog.eventType = eventData?.eventType || event?.type || "unknown";
+      eventLog.provider = "kingdomfunding";
+      eventLog.providerId = eventData?.id?.toString() || event?.id?.toString() || "";
+      eventLog.message = JSON.stringify(event);
+      await repos.eventLog.save(eventLog);
+    } catch (err) {
+      console.error("KingdomFunding logEvent error:", err);
+    }
+  }
+
+  async logDonation(
+    config: GatewayConfig,
+    churchId: string,
+    eventData: any,
+    repos: any,
+    status: "pending" | "complete" = "complete"
+  ): Promise<any> {
+    try {
+      // Extract amount — KingdomFunding uses auth_amount or amount_details.amount
+      let amount = eventData.auth_amount || eventData.amount || 0;
+      if (eventData.transaction?.amount_details?.amount) {
+        amount = eventData.transaction.amount_details.amount;
+      }
+
+      // Find person — from direct person data (charge flow) or from customer/transaction lookup (webhook flow)
+      let personId: string | undefined;
+      if (eventData.person?.id) {
+        personId = eventData.person.id;
+      } else {
+        // Try customer_id from webhook body
+        const customerId = eventData.customer?.customer_id || eventData.transaction?.customer?.customer_id;
+        if (customerId) {
+          const customer = await repos.customer.load(churchId, String(customerId));
+          if (customer) personId = customer.personId;
+        }
+
+        // Fallback: look up by reference_number in existing donations (charge endpoint logs first)
+        if (!personId) {
+          const refNum = eventData.reference_number || eventData.transaction?.id;
+          if (refNum) {
+            const existingDonation = await repos.donation.loadByTransactionId(churchId, String(refNum));
+            if (existingDonation?.personId) personId = existingDonation.personId;
+          }
+        }
+      }
+
+      // Determine payment method type
+      const isCheck = !!eventData.transaction?.check_details?.routing_number;
+      const method = isCheck ? "ACH" : "Card";
+      const methodDetails = isCheck
+        ? `Check ****${eventData.transaction?.check_details?.last4 || ""}`
+        : `${eventData.card_type || "Card"} ****${eventData.last_4 || ""}`;
+
+      const batch: DonationBatch = await repos.donationBatch.getOrCreateCurrent(churchId);
+
+      const refNumber = String(eventData.reference_number || eventData.transaction?.id || eventData.id || "");
+
+      // Use the actual transaction timestamp instead of "now" — webhooks may arrive much later
+      // (ACH webhooks can be days delayed). Falls back to now if no timestamp is provided.
+      let donationDate: Date = new Date();
+      const txTimestamp = eventData.transaction?.created_at || eventData.created_at || eventData.timestamp;
+      if (txTimestamp) {
+        const parsed = new Date(txTimestamp);
+        if (!isNaN(parsed.getTime())) donationDate = parsed;
+      }
+
+      const donation: Donation = {
+        churchId,
+        batchId: batch.id,
+        personId,
+        transactionId: refNumber,
+        donationDate,
+        amount,
+        method,
+        methodDetails,
+        notes: `KingdomFunding ref: ${refNumber}`,
+      };
+
+      const savedDonation = await repos.donation.save(donation);
+
+      // Allocate funds: subscription funds, charge funds array, or single fund fallback
+      const fundsArray = eventData.subscriptionFunds || eventData.funds || [];
+      if (fundsArray.length > 0) {
+        for (const fund of fundsArray) {
+          const fundDonation: FundDonation = {
+            churchId,
+            donationId: savedDonation.id,
+            fundId: fund.fundId || fund.id || "",
+            amount: fund.amount || 0,
+          };
+          await repos.fundDonation.save(fundDonation);
+        }
+      } else if (eventData.fundId) {
+        // Single fund donation — use the total amount
+        const fundDonation: FundDonation = {
+          churchId,
+          donationId: savedDonation.id,
+          fundId: eventData.fundId,
+          amount,
+        };
+        await repos.fundDonation.save(fundDonation);
+      }
+
+      return savedDonation;
+    } catch (err) {
+      console.error("KingdomFunding logDonation error:", err);
+      throw err;
+    }
+  }
+
+  async updateDonationStatus(
+    churchId: string,
+    transactionId: string,
+    status: "pending" | "complete" | "failed",
+    repos: any
+  ): Promise<void> {
+    try {
+      const donation = await repos.donation.loadByTransactionId(churchId, transactionId);
+      if (donation) {
+        // Update the donation status
+        // The method field can encode the status for now
+        await repos.donation.save({ ...donation, notes: `${donation.notes || ""} [status: ${status}]` });
+      }
+    } catch (err) {
+      console.error("KingdomFunding updateDonationStatus error:", err);
+    }
+  }
+}

--- a/src/shared/helpers/gateways/__tests__/KingdomFundingGatewayProvider.test.ts
+++ b/src/shared/helpers/gateways/__tests__/KingdomFundingGatewayProvider.test.ts
@@ -1,0 +1,82 @@
+// Environment + models use ESM-only constructs / DB wiring that don't load under
+// ts-jest's commonjs transform, and verifyWebhookSignature needs neither — stub them.
+jest.mock("../../Environment", () => ({ Environment: { membershipApi: "http://test" } }));
+jest.mock("../../../../modules/giving/models/index", () => ({
+  Donation: class {},
+  DonationBatch: class {},
+  EventLog: class {},
+  FundDonation: class {},
+}));
+
+import crypto from "crypto";
+import { KingdomFundingGatewayProvider } from "../KingdomFundingGatewayProvider";
+
+describe("KingdomFundingGatewayProvider.verifyWebhookSignature (NMI)", () => {
+  const provider = new KingdomFundingGatewayProvider();
+  const secret = "whsec_test_signing_key";
+  const nonce = "1718900000";
+
+  const payloadObj = {
+    event_id: "evt_abc123",
+    event_type: "transaction.sale.success",
+    event_body: { transaction: { transaction_id: "12202439231", amount: "10.00", cc_type: "visa" } },
+  };
+  const rawPayload = JSON.stringify(payloadObj);
+
+  const sign = (raw: string) =>
+    crypto.createHmac("sha256", secret).update(`${nonce}.${raw}`, "utf-8").digest("hex");
+
+  const baseConfig: any = {
+    gatewayId: "g1", churchId: "c1", publicKey: "pk", privateKey: "sk", webhookKey: secret,
+  };
+  const validHeaders = (raw: string) => ({ "webhook-signature": `t=${nonce},s=${sign(raw)}` });
+
+  it("accepts a correctly-signed payload as a raw STRING (production path)", async () => {
+    const res = await provider.verifyWebhookSignature(baseConfig, validHeaders(rawPayload) as any, rawPayload);
+    expect(res.success).toBe(true);
+    expect(res.shouldProcess).toBe(true);
+    expect(res.eventId).toBe("evt_abc123");
+    expect(res.eventType).toBe("transaction.sale.success");
+    expect(res.eventData?.id).toBe("12202439231");
+  });
+
+  it("accepts the same payload delivered as a BUFFER (local-dev path)", async () => {
+    // This is the case the fix addresses: JSON.stringify(buffer) would never match.
+    const res = await provider.verifyWebhookSignature(baseConfig, validHeaders(rawPayload) as any, Buffer.from(rawPayload, "utf8"));
+    expect(res.success).toBe(true);
+    expect(res.shouldProcess).toBe(true);
+    expect(res.eventData?.id).toBe("12202439231");
+  });
+
+  it("rejects a tampered signature", async () => {
+    const headers = { "webhook-signature": `t=${nonce},s=${"0".repeat(64)}` };
+    const res = await provider.verifyWebhookSignature(baseConfig, headers as any, rawPayload);
+    expect(res.success).toBe(false);
+    expect(res.shouldProcess).toBe(false);
+  });
+
+  it("rejects when the body is altered after signing", async () => {
+    const tamperedBody = rawPayload.replace("10.00", "9999.00");
+    const res = await provider.verifyWebhookSignature(baseConfig, validHeaders(rawPayload) as any, tamperedBody);
+    expect(res.success).toBe(false);
+  });
+
+  it("rejects when no signing key is configured", async () => {
+    const res = await provider.verifyWebhookSignature({ ...baseConfig, webhookKey: "" }, validHeaders(rawPayload) as any, rawPayload);
+    expect(res.success).toBe(false);
+    expect(res.shouldProcess).toBe(false);
+  });
+
+  it("rejects when the signature header is missing", async () => {
+    const res = await provider.verifyWebhookSignature(baseConfig, {} as any, rawPayload);
+    expect(res.success).toBe(false);
+  });
+
+  it("verifies but does not process an unhandled event type", async () => {
+    const otherObj = { event_id: "evt_x", event_type: "transaction.void.success", event_body: {} };
+    const raw = JSON.stringify(otherObj);
+    const res = await provider.verifyWebhookSignature(baseConfig, validHeaders(raw) as any, raw);
+    expect(res.success).toBe(true);
+    expect(res.shouldProcess).toBe(false);
+  });
+});

--- a/tools/seed-nmi-gateway.ts
+++ b/tools/seed-nmi-gateway.ts
@@ -1,0 +1,46 @@
+// Local-dev helper: add a Kingdom Funding (NMI) gateway to the demo Grace church.
+// Encrypts the NMI secrets exactly like GatewayController does, then inserts the row.
+// Run: npx tsx tools/seed-nmi-gateway.ts
+import dotenv from "dotenv";
+import mysql from "mysql2/promise";
+import { EncryptionHelper, EnvironmentBase } from "@churchapps/apihelper";
+
+dotenv.config();
+EnvironmentBase.encryptionKey = process.env.ENCRYPTION_KEY || "";
+
+const CHURCH_ID = "CHU00000001";
+const GATEWAY_ID = "GAT00000003";
+
+async function main() {
+  const securityKey = process.env.NMI_SECURITY_KEY || "";
+  const tokenizationKey = process.env.NMI_TOKENIZATION_KEY || "";
+  const webhookKey = process.env.NMI_WEBHOOK_KEY || "";
+  if (!securityKey || !tokenizationKey) throw new Error("NMI_SECURITY_KEY / NMI_TOKENIZATION_KEY missing from .env");
+
+  const conn = await mysql.createConnection({ host: "localhost", port: 3306, user: "root", password: "b1local", database: "giving" });
+
+  await conn.execute("DELETE FROM gateways WHERE id = ?", [GATEWAY_ID]);
+  await conn.execute(
+    `INSERT INTO gateways (id, churchId, provider, publicKey, privateKey, webhookKey, productId, payFees, currency, settings, environment)
+     VALUES (?, ?, 'kingdomfunding', ?, ?, ?, '', 0, 'USD', ?, 'sandbox')`,
+    [
+      GATEWAY_ID,
+      CHURCH_ID,
+      tokenizationKey,                                  // publicKey — plaintext (browser)
+      EncryptionHelper.encrypt(securityKey),            // privateKey — encrypted
+      webhookKey ? EncryptionHelper.encrypt(webhookKey) : "",
+      JSON.stringify({ sandbox: true }),
+    ]
+  );
+
+  const [rows] = await conn.query("SELECT id, provider, churchId, publicKey, environment FROM gateways WHERE id = ?", [GATEWAY_ID]);
+  console.log("Inserted gateway:", rows);
+
+  // Sanity: confirm round-trip decrypt matches the original security key.
+  const [enc]: any = await conn.query("SELECT privateKey FROM gateways WHERE id = ?", [GATEWAY_ID]);
+  const decrypted = EncryptionHelper.decrypt(enc[0].privateKey);
+  console.log("Decrypt round-trip OK:", decrypted === securityKey);
+
+  await conn.end();
+}
+main().then(() => process.exit(0)).catch((e) => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Kingdom Funding gateway via NMI (Accept Blue → NMI)

Implements the Kingdom Funding payment gateway on **NMI** (Network Merchants Inc.) instead of Accept Blue. The motivation is ACH: Accept Blue cannot tokenize bank accounts, while NMI **Collect.js** tokenizes **both card and ACH** into a single-use `payment_token`, so donors can give by card *or* bank account.

This is internals-only — the "Kingdom Funding" name, branding, signup flow, locale strings, dropdown labels, and the admin gateway-settings page are unchanged. (This is the NMI version of the earlier Kingdom Funding work; supersedes the Accept Blue approach.)

### Highlights
- **Backend (Api):** `KingdomFundingGatewayProvider` on the NMI Payment API (`transact.php`) — card+ACH charge via `payment_token`, Customer Vault for saved methods, recurring subscriptions, refund/void, and `Webhook-Signature` HMAC-SHA256 verification.
- **Frontend (Packages/apphelper):** NMI Collect.js with a card/bank toggle; ACH tokenized client-side (no raw bank numbers reach the backend).
- **Credentials** map to the existing `gateways` columns: `publicKey` = Collect.js tokenization key, `privateKey` = NMI Security Key, `webhookKey` = NMI signing key.

### Verification
- `tsc` clean (Api + apphelper); gateway unit tests pass.
- Live NMI sandbox: card, debit, ACH, vault, recurring, void, refund all approved.
- Full browser end-to-end (Collect.js → Api → NMI sandbox → donation + fund logged) for card and ACH.

`NMI_MIGRATION_HANDOFF.md` (in the Api PR) has setup, local-test, and config details. Note: the branch is based on the Kingdom Funding integration and is behind current `main`, so a merge/rebase may be needed on your side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
