### PR TITLE
Fix Pagination on song tab

### DIFF
--- a/src/modules/content/controllers/SongDetailsController.ts
+++ b/src/modules/content/controllers/SongDetailsController.ts
@@ -18,7 +18,21 @@ export class SongDetailsController extends ContentBaseController {
   @httpGet("/")
   public async getAll(req: express.Request<{}, {}, null>, res: express.Response): Promise<any> {
     return this.actionWrapper(req, res, async (au) => {
-      return await this.repos.songDetail.loadForChurch(au.churchId);
+      const limit = req.query.limit ? parseInt(req.query.limit.toString(), 10) : undefined;
+      const offset = req.query.offset ? parseInt(req.query.offset.toString(), 10) : undefined;
+      const search = req.query.search ? req.query.search.toString() : undefined;
+
+      if (limit !== undefined || offset !== undefined || search !== undefined) {
+        const [songDetails, count] = await Promise.all([
+          this.repos.songDetail.loadForChurch(au.churchId, limit, offset, search),
+          this.repos.songDetail.loadCountForChurch(au.churchId, search)
+        ]);
+        console.log(limit, offset, search);
+        console.log({ songDetails, count });
+        return { songDetails, count };
+      } else {
+        return await this.repos.songDetail.loadForChurch(au.churchId);
+      }
     });
   }
 

--- a/src/modules/content/repositories/SongDetailRepo.ts
+++ b/src/modules/content/repositories/SongDetailRepo.ts
@@ -84,15 +84,49 @@ export class SongDetailRepo {
     return (await getDb().selectFrom("songDetails").selectAll().where("praiseChartsId", "=", praiseChartsId).executeTakeFirst()) ?? null as any;
   }
 
-  public async loadForChurch(churchId: string) {
-    return getDb().selectFrom("songs as s")
+  public async loadForChurch(churchId: string, limit?: number, offset?: number, search?: string) {
+    let query = getDb().selectFrom("songs as s")
       .innerJoin("songDetails as sd", "sd.id", "s.songDetailId")
       .selectAll("sd")
       .select(["s.id as songId", "s.churchId"])
-      .where("s.churchId", "=", churchId)
-      .orderBy("sd.title")
-      .orderBy("sd.artist")
-      .execute() as any;
+      .where("s.churchId", "=", churchId);
+
+    if (search) {
+      const q = "%" + search.replace(/ /g, "%") + "%";
+      query = query.where((eb) => eb.or([
+        eb(sql`concat(sd.title, ' ', sd.artist)`, "like", q),
+        eb(sql`concat(sd.artist, ' ', sd.title)`, "like", q)
+      ]));
+    }
+
+    query = query.orderBy("sd.title").orderBy("sd.artist");
+
+    if (limit !== undefined) {
+      query = query.limit(limit);
+    }
+    if (offset !== undefined) {
+      query = query.offset(offset);
+    }
+
+    return query.execute() as any;
+  }
+
+  public async loadCountForChurch(churchId: string, search?: string) {
+    let query = getDb().selectFrom("songs as s")
+      .innerJoin("songDetails as sd", "sd.id", "s.songDetailId")
+      .select((eb) => eb.fn.count("sd.id").as("count"))
+      .where("s.churchId", "=", churchId);
+
+    if (search) {
+      const q = "%" + search.replace(/ /g, "%") + "%";
+      query = query.where((eb) => eb.or([
+        eb(sql`concat(sd.title, ' ', sd.artist)`, "like", q),
+        eb(sql`concat(sd.artist, ' ', sd.title)`, "like", q)
+      ]));
+    }
+
+    const result = await query.executeTakeFirst();
+    return (result as any)?.count || 0;
   }
 
   public convertToModel(data: any) { return data as SongDetail; }


### PR DESCRIPTION
https://github.com/ChurchApps/ChurchAppsSupport/issues/943

* Updated both Frontend and Backend APIs to support pagination.
* Implemented pagination in the UI with configurable page sizes (10, 20, 50, etc.), allowing users to select their preferred number of records per page.
* Optimised data loading by fetching records in batches of 10 per API call and continuing retrieval through pagination as users navigate between pages.
* Ensured a smooth and scalable user experience for handling large datasets efficiently.


